### PR TITLE
Tokenize whitespace strings correctly

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -4,6 +4,24 @@
  */
 
 /**
+ * Helper function to trim a string, speed optimized.
+ * See: http://blog.stevenlevithan.com/archives/faster-trim-javascript
+ * 
+ * @param {String} str The string to trim
+ * @returns {String}
+ */
+lunr.trim = function (str) {
+  str = str.replace(/^\s+/, '');
+	for (var i = str.length - 1; i >= 0; i--) {
+		if (/\S/.test(str.charAt(i))) {
+			str = str.substring(0, i + 1);
+			break;
+		}
+	}
+	return str;
+}
+
+/**
  * A function for splitting a string into tokens ready to be inserted into
  * the search index.
  *
@@ -16,7 +34,7 @@ lunr.tokenizer = function (str) {
 
   var whiteSpaceSplitRegex = /\s+/
 
-  return str.split(whiteSpaceSplitRegex).map(function (token) {
+  return lunr.trim(str).split(whiteSpaceSplitRegex).map(function (token) {
     return token.replace(/^\W+/, '').replace(/\W+$/, '').toLowerCase()
   })
 }


### PR DESCRIPTION
Tokenizing " hello" (note leading space) currently results in 2 tokens: ["","hello"]. Should be ["hello"]. See PR for fix
