### PR TITLE
Fix for Loading a Previously Serialized Index

### DIFF
--- a/lunr.js
+++ b/lunr.js
@@ -960,7 +960,7 @@ lunr.Store.load = function (serialisedData) {
 
   store.length = serialisedData.length
   store.store = Object.keys(serialisedData.store).reduce(function (memo, key) {
-    memo[key] = lunr.SortedSet.load(serialisedData.store[key])
+    memo[key] = lunr.SortedSet.load(serialisedData.store[key].elements)
     return memo
   }, {})
 


### PR DESCRIPTION
### See issue #18

As demonstrated below, when loading a serialized index, lunr.js incorrectly loads the serialized index's documentStore.

First, create an index, add a document to the index, and log the `index.documentStore.store` to show its correct form:

``` javascript
var index = lunr(function () { //create index
    this.field('title')
    this.ref('id')
})
index.add({id: 100, title: 'apple' }) //add document to index
console.log(index.documentStore.store) //log documentStore.store before serializing index
```

The following is the log of the `index.documentStore.store` in its correct form:

```
{ '100': { length: 1, elements: [ 'appl' ] } }
```

Then, serialize the index and store it to the database:

``` javascript
user.index = index.toJSON() //serialize index and store it in the database
user.save() //save changes to database
```

Load the serialized index and log the `index.documentStore.store` to show it in its **incorrect** form:

``` javascript
index = lunr.Index.load(user.index) //load previously serialized index from database
console.log(index.documentStore.store) //log incorrect documentStore after loading serialized index
```

The following is the log of the `index.documentStore.store` in its **incorrect** form:

```
{ '100': { length: 1, elements: { length: 1, elements: [Object] } } }
```

**Bug:** The bug occurs on line `962` of `lunr.js` in the `lunr.Store.load()` function, which is called in `lunr.Index.load()`. Simply, this is fixed by changing

``` javascript
memo[key] = lunr.SortedSet.load(serialisedData.store[key])
```

to

``` javascript
memo[key] = lunr.SortedSet.load(serialisedData.store[key].elements)
```
