### PR TITLE
Fixes for Incorrect Sidebar Links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -315,19 +315,19 @@ code .comment {
               
                 <li><a href='#warnIfFunctionNotRegistered'>warnIfFunctionNotRegistered</a></li>
               
-                <li><a href='#load'>load</a></li>
+                <li><a href='#Pipeline-load'>load</a></li>
               
-                <li><a href='#add'>add</a></li>
+                <li><a href='#Pipeline-add'>add</a></li>
               
                 <li><a href='#after'>after</a></li>
               
                 <li><a href='#before'>before</a></li>
               
-                <li><a href='#remove'>remove</a></li>
+                <li><a href='#Pipeline-remove'>remove</a></li>
               
                 <li><a href='#run'>run</a></li>
               
-                <li><a href='#toJSON'>toJSON</a></li>
+                <li><a href='#Pipeline-toJSON'>toJSON</a></li>
               
             </ul>
           </li>
@@ -345,7 +345,7 @@ code .comment {
               
                 <li><a href='#similarity'>similarity</a></li>
               
-                <li><a href='#toArray'>toArray</a></li>
+                <li><a href='#Vector-toArray'>toArray</a></li>
               
             </ul>
           </li>
@@ -357,11 +357,11 @@ code .comment {
 
             <ul>
               
-                <li><a href='#load'>load</a></li>
+                <li><a href='#SortedSet-load'>load</a></li>
               
-                <li><a href='#add'>add</a></li>
+                <li><a href='#SortedSet-add'>add</a></li>
               
-                <li><a href='#toArray'>toArray</a></li>
+                <li><a href='#SortedSet-toArray'>toArray</a></li>
               
                 <li><a href='#map'>map</a></li>
               
@@ -377,7 +377,7 @@ code .comment {
               
                 <li><a href='#union'>union</a></li>
               
-                <li><a href='#toJSON'>toJSON</a></li>
+                <li><a href='#SortedSet-toJSON'>toJSON</a></li>
               
             </ul>
           </li>
@@ -389,15 +389,15 @@ code .comment {
 
             <ul>
               
-                <li><a href='#load'>load</a></li>
+                <li><a href='#Index-load'>load</a></li>
               
                 <li><a href='#field'>field</a></li>
               
                 <li><a href='#ref'>ref</a></li>
               
-                <li><a href='#add'>add</a></li>
+                <li><a href='#Index-add'>add</a></li>
               
-                <li><a href='#remove'>remove</a></li>
+                <li><a href='#Index-remove'>remove</a></li>
               
                 <li><a href='#update'>update</a></li>
               
@@ -407,7 +407,7 @@ code .comment {
               
                 <li><a href='#documentVector'>documentVector</a></li>
               
-                <li><a href='#toJSON'>toJSON</a></li>
+                <li><a href='#Index-toJSON'>toJSON</a></li>
               
             </ul>
           </li>
@@ -419,17 +419,17 @@ code .comment {
 
             <ul>
               
-                <li><a href='#load'>load</a></li>
+                <li><a href='#Store-load'>load</a></li>
               
                 <li><a href='#set'>set</a></li>
               
-                <li><a href='#get'>get</a></li>
+                <li><a href='#Store-get'>get</a></li>
               
-                <li><a href='#has'>has</a></li>
+                <li><a href='#Store-has'>has</a></li>
               
-                <li><a href='#remove'>remove</a></li>
+                <li><a href='#Store-remove'>remove</a></li>
               
-                <li><a href='#toJSON'>toJSON</a></li>
+                <li><a href='#Store-toJSON'>toJSON</a></li>
               
             </ul>
           </li>
@@ -461,21 +461,21 @@ code .comment {
 
             <ul>
               
-                <li><a href='#load'>load</a></li>
+                <li><a href='#TokenStore-load'>load</a></li>
               
-                <li><a href='#add'>add</a></li>
+                <li><a href='#TokenStore-add'>add</a></li>
               
-                <li><a href='#has'>has</a></li>
+                <li><a href='#TokenStore-has'>has</a></li>
               
                 <li><a href='#getNode'>getNode</a></li>
               
-                <li><a href='#get'>get</a></li>
+                <li><a href='#TokenStore-get'>get</a></li>
               
-                <li><a href='#remove'>remove</a></li>
+                <li><a href='#TokenStore-remove'>remove</a></li>
               
                 <li><a href='#expand'>expand</a></li>
               
-                <li><a href='#toJSON'>toJSON</a></li>
+                <li><a href='#TokenStore-toJSON'>toJSON</a></li>
               
             </ul>
           </li>
@@ -646,7 +646,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='load'>
+            <section class='method' id='Pipeline-load'>
               <header>
                 <h3>load</h3>
                 <h4>lunr.Pipeline.load()</h4>
@@ -696,7 +696,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='add'>
+            <section class='method' id='Pipeline-add'>
               <header>
                 <h3>add</h3>
                 <h4>lunr.Pipeline.prototype.add()</h4>
@@ -825,7 +825,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='remove'>
+            <section class='method' id='Pipeline-remove'>
               <header>
                 <h3>remove</h3>
                 <h4>lunr.Pipeline.prototype.remove()</h4>
@@ -913,7 +913,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='toJSON'>
+            <section class='method' id='Pipeline-toJSON'>
               <header>
                 <h3>toJSON</h3>
                 <h4>lunr.Pipeline.prototype.toJSON()</h4>
@@ -1088,7 +1088,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='toArray'>
+            <section class='method' id='Vector-toArray'>
               <header>
                 <h3>toArray</h3>
                 <h4>lunr.Vector.prototype.toArray()</h4>
@@ -1132,7 +1132,7 @@ code .comment {
           </section>
 
           
-            <section class='method' id='load'>
+            <section class='method' id='SortedSet-load'>
               <header>
                 <h3>load</h3>
                 <h4>lunr.SortedSet.load()</h4>
@@ -1173,7 +1173,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='add'>
+            <section class='method' id='SortedSet-add'>
               <header>
                 <h3>add</h3>
                 <h4>lunr.SortedSet.prototype.add()</h4>
@@ -1214,7 +1214,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='toArray'>
+            <section class='method' id='SortedSet-toArray'>
               <header>
                 <h3>toArray</h3>
                 <h4>lunr.SortedSet.prototype.toArray()</h4>
@@ -1582,7 +1582,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='toJSON'>
+            <section class='method' id='SortedSet-toJSON'>
               <header>
                 <h3>toJSON</h3>
                 <h4>lunr.SortedSet.prototype.toJSON()</h4>
@@ -1626,7 +1626,7 @@ code .comment {
           </section>
 
           
-            <section class='method' id='load'>
+            <section class='method' id='Index-load'>
               <header>
                 <h3>load</h3>
                 <h4>lunr.Index.load()</h4>
@@ -1763,7 +1763,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='add'>
+            <section class='method' id='Index-add'>
               <header>
                 <h3>add</h3>
                 <h4>lunr.Index.prototype.add()</h4>
@@ -1825,7 +1825,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='remove'>
+            <section class='method' id='Index-remove'>
               <header>
                 <h3>remove</h3>
                 <h4>lunr.Index.prototype.remove()</h4>
@@ -2097,7 +2097,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='toJSON'>
+            <section class='method' id='Index-toJSON'>
               <header>
                 <h3>toJSON</h3>
                 <h4>lunr.Index.prototype.toJSON()</h4>
@@ -2149,7 +2149,7 @@ code .comment {
           </section>
 
           
-            <section class='method' id='load'>
+            <section class='method' id='Store-load'>
               <header>
                 <h3>load</h3>
                 <h4>lunr.Store.load()</h4>
@@ -2232,7 +2232,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='get'>
+            <section class='method' id='Store-get'>
               <header>
                 <h3>get</h3>
                 <h4>lunr.Store.prototype.get()</h4>
@@ -2268,7 +2268,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='has'>
+            <section class='method' id='Store-has'>
               <header>
                 <h3>has</h3>
                 <h4>lunr.Store.prototype.has()</h4>
@@ -2304,7 +2304,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='remove'>
+            <section class='method' id='Store-remove'>
               <header>
                 <h3>remove</h3>
                 <h4>lunr.Store.prototype.remove()</h4>
@@ -2343,7 +2343,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='toJSON'>
+            <section class='method' id='Store-toJSON'>
               <header>
                 <h3>toJSON</h3>
                 <h4>lunr.Store.prototype.toJSON()</h4>
@@ -2416,7 +2416,7 @@ code .comment {
           </section>
 
           
-            <section class='method' id='load'>
+            <section class='method' id='TokenStore-load'>
               <header>
                 <h3>load</h3>
                 <h4>lunr.TokenStore.load()</h4>
@@ -2457,7 +2457,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='add'>
+            <section class='method' id='TokenStore-add'>
               <header>
                 <h3>add</h3>
                 <h4>lunr.TokenStore.prototype.add()</h4>
@@ -2511,7 +2511,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='has'>
+            <section class='method' id='TokenStore-has'>
               <header>
                 <h3>has</h3>
                 <h4>lunr.TokenStore.prototype.has()</h4>
@@ -2611,7 +2611,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='get'>
+            <section class='method' id='TokenStore-get'>
               <header>
                 <h3>get</h3>
                 <h4>lunr.TokenStore.prototype.get()</h4>
@@ -2651,7 +2651,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='remove'>
+            <section class='method' id='TokenStore-remove'>
               <header>
                 <h3>remove</h3>
                 <h4>lunr.TokenStore.prototype.remove()</h4>
@@ -2752,7 +2752,7 @@ code .comment {
               
             </section>
           
-            <section class='method' id='toJSON'>
+            <section class='method' id='TokenStore-toJSON'>
               <header>
                 <h3>toJSON</h3>
                 <h4>lunr.TokenStore.prototype.toJSON()</h4>


### PR DESCRIPTION
Functions with the same name had the same id. For example, `lunr.Pipeline.load()`, `lunr.SortedSet.load()`, `lunr.Index.load()`, etc., all had `id='load'`, so every `href='#load'` link in the sidebar jumped to `lunr.Pipeline.load()`, because it was the first `id='load'` on the page. These changes give every identically named function a unique id, such as, `#Pipeline-load`, `#SortedSet-load`, and `#Index-load`, so that the sidebar behaves correctly.
