### PR TITLE
Fixes 64

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -245,7 +245,7 @@ lunr.Index.prototype.update = function (doc, emitEvent) {
  * @memberOf Index
  */
 lunr.Index.prototype.idf = function (term) {
-  if (this._idfCache[term]) return this._idfCache[term]
+  if (this._idfCache[term] && this.hasOwnProperty(term)) return this._idfCache[term]
 
   var documentFrequency = this.tokenStore.count(term),
       idf = 1

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -285,3 +285,33 @@ test('loading a serialised index', function () {
   deepEqual(idx._fields, serialisedData.fields)
   equal(idx._ref, 'id')
 })
+
+;(function() {
+
+  function _test(prop) {
+    var idx = new lunr.Index,
+      results
+
+    idx.field('body')
+    idx.add({
+      body: prop
+    })
+
+    results = idx.search(prop)
+    equal(results.length, 1, '[' + prop + '] results.length=1')
+    ok(!isNaN(results[0].score), '[' + prop + '] !isNaN(results[0].score)')
+  }
+
+  test('indexing Object.prototype properties which are all lowercase', function () {
+    ['constructor', '__proto__'].forEach(function(prop) {
+      _test(prop)
+    })
+  })
+
+  test('indexing Object.prototype properties which are not all lowercase', function () {
+    ['hasOwnProperty', 'isPrototypeOf', 'propertyIsEnumerable', 'toLocaleString', 'toString', 'valueOf'].forEach(function(prop) {
+      _test(prop)
+    })
+  })
+
+}())


### PR DESCRIPTION
Added hasOwnProperty() test to lunr.Index.prototype.idf() so that words
like `constructor` and `_ _ proto _ _` can be indexed.
