### PR TITLE
Preserve tags during tokenization

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -27,6 +27,6 @@ lunr.tokenizer = function (obj) {
   return str
     .split(/\s+/)
     .map(function (token) {
-      return token.replace(/^\W+/, '').replace(/\W+$/, '').toLowerCase()
+      return token.replace(/^[^<>\w]+/, '').replace(/[^<>\w]$/, '').toLowerCase()
     })
 }

--- a/lunr.js
+++ b/lunr.js
@@ -208,7 +208,7 @@ lunr.tokenizer = function (obj) {
   return str
     .split(/\s+/)
     .map(function (token) {
-      return token.replace(/^\W+/, '').replace(/\W+$/, '').toLowerCase()
+      return token.replace(/^[^<>\w]+/, '').replace(/[^<>\w]+$/, '').toLowerCase()
     })
 }
 /*!

--- a/test/tokenizer_test.js
+++ b/test/tokenizer_test.js
@@ -66,3 +66,14 @@ test('calling to string on passed val', function () {
   deepEqual(lunr.tokenizer(date).slice(0, 4), ['tue', 'jan', '01', '2013'])
 })
 
+test('ensuring tags are preserved', function() {
+  var testString = '<p>Login using your social account:</p>',
+      tokens = lunr.tokenizer(testString)
+
+  deepEqual(tokens, ['<p>login', 'using', 'your', 'social', 'account:</p>'])
+
+  var tagString = '<audio>',
+      tagToken = lunr.tokenizer(tagString)
+
+  deepEqual(tagToken, ['<audio>'])
+})


### PR DESCRIPTION
The regex substitutions on each token would truncate the open or closing
bracket of a tag, as they aren't discluded by \W. This caused issues for me
when I was trying to get my custom htmlStripper() pipeline function to work,
which strips out HTML tags to provide more accurate results, because it
wouldn't be able to match partial HTML tags. I propose that these be added
to core so anyone who could be indexing tokens that include tags won't have
to dig into the tokenizer and patch it themselves.
