### PR TITLE
Split on hyphens as well as whitespace

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -25,7 +25,7 @@ lunr.tokenizer = function (obj) {
   }
 
   return str
-    .split(/\s+/)
+    .split(/(?:\s+|\-)/)
     .map(function (token) {
       return token.toLowerCase()
     })

--- a/test/tokenizer_test.js
+++ b/test/tokenizer_test.js
@@ -50,3 +50,9 @@ test('calling to string on passed val', function () {
   deepEqual(lunr.tokenizer(date).slice(0, 4), ['tue', 'jan', '01', '2013'])
 })
 
+test("splitting strings with hyphens", function () {
+  var simpleString = "take the New York-San Francisco flight",
+      tokens = lunr.tokenizer(simpleString)
+
+  deepEqual(tokens, ['take', 'the', 'new', 'york', 'san', 'francisco', 'flight'])
+})


### PR DESCRIPTION
Example:

```
Take the New York-San Francisco flight.
```

"york-san" isn't a word, so it shouldn't be output by the tokenizer.

For precedence, [Lucene's standard tokenizer also splits on hyphens](https://lucene.apache.org/core/3_0_3/api/core/org/apache/lucene/analysis/standard/StandardTokenizer.html), although it doesn't do it for product numbers like 31-5-6, which is not implemented here due to complexity.

Prompted by https://github.com/nolanlawson/pouchdb-quick-search/issues/3.
