### PR TITLE
Manually set document store length on set()

### DIFF
--- a/lib/document_store.js
+++ b/lib/document_store.js
@@ -42,8 +42,8 @@ lunr.Store.load = function (serialisedData) {
  * @memberOf Store
  */
 lunr.Store.prototype.set = function (id, tokens) {
+  if (!Object.prototype.hasOwnProperty.call(this.store, id)) this.length++
   this.store[id] = tokens
-  this.length = Object.keys(this.store).length
 }
 
 /**


### PR DESCRIPTION
Repeatedly calling `Object.keys(this.store).length` is very expensive and dramatically slows the indexing process for larger data sets.

On my data set of around 15k items, this change reduces the index time from 23 seconds to 4.

Tests all still pass.

An alternative would be to make length a getter method which runs `Object.keys(this.store).length`.

Thanks!
