### PR TITLE
Fix inefficient arguments

### DIFF
--- a/lib/event_emitter.js
+++ b/lib/event_emitter.js
@@ -22,16 +22,17 @@ lunr.EventEmitter = function () {
  * @memberOf EventEmitter
  */
 lunr.EventEmitter.prototype.addListener = function () {
-  var args = Array.prototype.slice.call(arguments),
-      fn = args.pop(),
-      names = args
+  var i, fn, name
 
+  if (arguments.length < 2) throw new TypeError("missing parameters")
+  fn = arguments[arguments.length - 1]
   if (typeof fn !== "function") throw new TypeError ("last argument must be a function")
 
-  names.forEach(function (name) {
+  for (i = 0; i < arguments.length - 1; ++i) {
+    name = arguments[i]
     if (!this.hasHandler(name)) this.events[name] = []
     this.events[name].push(fn)
-  }, this)
+  }
 }
 
 /**
@@ -62,11 +63,17 @@ lunr.EventEmitter.prototype.removeListener = function (name, fn) {
 lunr.EventEmitter.prototype.emit = function (name) {
   if (!this.hasHandler(name)) return
 
-  var args = Array.prototype.slice.call(arguments, 1)
+  var i,
+      args = new Array(arguments.length - 1)
+      event = this.events[name]
 
-  this.events[name].forEach(function (fn) {
-    fn.apply(undefined, args)
-  })
+  for (i = 0; i < args.length; ++i) {
+    args[i] = arguments[i + 1]
+  }
+
+  for (i = 0; i < event.length; ++i) {
+    event[i].apply(undefined, args)
+  }
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,8 +36,7 @@ lunr.Index = function () {
  * @memberOf Index
  */
 lunr.Index.prototype.on = function () {
-  var args = Array.prototype.slice.call(arguments)
-  return this.eventEmitter.addListener.apply(this.eventEmitter, args)
+  return this.eventEmitter.addListener.apply(this.eventEmitter, arguments)
 }
 
 /**
@@ -415,7 +414,12 @@ lunr.Index.prototype.toJSON = function () {
  * @memberOf Index
  */
 lunr.Index.prototype.use = function (plugin) {
-  var args = Array.prototype.slice.call(arguments, 1)
-  args.unshift(this)
+  var i, args = new Array(arguments.length)
+  args[0] = this
+
+  for (i = 1; i < args.length; ++i) {
+    args[i] = arguments[i]
+  }
+
   plugin.apply(this, args)
 }

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -111,12 +111,12 @@ lunr.Pipeline.load = function (serialised) {
  * @memberOf Pipeline
  */
 lunr.Pipeline.prototype.add = function () {
-  var fns = Array.prototype.slice.call(arguments)
-
-  fns.forEach(function (fn) {
+  var i, fn
+  for (i = 0; i < arguments.length; ++i) {
+    fn = arguments[i]
     lunr.Pipeline.warnIfFunctionNotRegistered(fn)
     this._stack.push(fn)
-  }, this)
+  }
 }
 
 /**

--- a/lib/sorted_set.js
+++ b/lib/sorted_set.js
@@ -38,10 +38,13 @@ lunr.SortedSet.load = function (serialisedData) {
  * @memberOf SortedSet
  */
 lunr.SortedSet.prototype.add = function () {
-  Array.prototype.slice.call(arguments).forEach(function (element) {
-    if (~this.indexOf(element)) return
+  var i, element
+
+  for (i = 0; i < arguments.length; ++i) {
+    element = arguments[i]
+    if (~this.indexOf(element)) continue
     this.elements.splice(this.locationFor(element), 0, element)
-  }, this)
+  }
 
   this.length = this.elements.length
 }

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 var http = require('http'),
     url = require('url'),
     join = require('path').join,
-    exists = require('path').exists,
+    exists = require('fs').exists,
     extname = require('path').extname,
     join = require('path').join,
     fs = require('fs'),


### PR DESCRIPTION
This changes all Array.prototype.slice.call(arguments) into for loops. This is
to avoid performance issues with [deoptimization][1].

[1]: https://github.com/petkaantonov/bluebird/wiki/Optimization-killers