### PR TITLE
Tokenizer performance improvement

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -15,21 +15,6 @@ lunr.tokenizer = function (obj) {
   if (!arguments.length || obj == null || obj == undefined) return []
   if (Array.isArray(obj)) return obj.map(function (t) { return t.toLowerCase() })
 
-  var str = obj.toString().replace(/^\s+/, '')
-
-  for (var i = str.length - 1; i >= 0; i--) {
-    if (/\S/.test(str.charAt(i))) {
-      str = str.substring(0, i + 1)
-      break
-    }
-  }
-
-  return str
-    .split(/(?:\s+|\-)/)
-    .filter(function (token) {
-      return !!token
-    })
-    .map(function (token) {
-      return token.toLowerCase()
-    })
+  return obj.toString().trim().toLowerCase().split(/[\s\-]+/)
 }
+

--- a/test/tokenizer_test.js
+++ b/test/tokenizer_test.js
@@ -36,7 +36,7 @@ test('handling null-like arguments', function () {
 })
 
 test('calling to string on passed val', function () {
-  var date = new Date (Date.UTC(2013, 0, 1)),
+  var date = new Date (Date.UTC(2013, 0, 1, 12)),
       obj = {
         toString: function () { return 'custom object' }
       }


### PR DESCRIPTION
I know that the CONTRIBUTING doc says to open an issue first, but this was a small change (and just a refactor). Please feel free to close if it's not inbounds.

Made a couple of changes to the tokenizer that make the implementation shorter and faster:

1. Use `String.prototype.trim`
2. Change the regex so that filtering out empty matches is not necessary
3. Call `toLowerCase` once instead of repeatedly in `map`

Removing the calls to `map` and `filter` results in pretty big speed
improvements (2X-4X), and probably (haven't tested it) lower memory
usage.

http://jsperf.com/stringsplitting