### PR TITLE
Fix vector magnitude caching

### DIFF
--- a/lib/vector.js
+++ b/lib/vector.js
@@ -40,6 +40,7 @@ lunr.Vector.Node = function (idx, val, next) {
  * @memberOf Vector.
  */
 lunr.Vector.prototype.insert = function (idx, val) {
+  this._magnitude = undefined;
   var list = this.list
 
   if (!list) {

--- a/lib/vector.js
+++ b/lib/vector.js
@@ -70,7 +70,7 @@ lunr.Vector.prototype.insert = function (idx, val) {
  * @memberOf Vector
  */
 lunr.Vector.prototype.magnitude = function () {
-  if (this._magniture) return this._magnitude
+  if (this._magnitude) return this._magnitude
   var node = this.list,
       sumOfSquares = 0,
       val

--- a/test/vector_test.js
+++ b/test/vector_test.js
@@ -37,3 +37,15 @@ test("calculating the similarity between two vectors", function () {
   equal(roundedSimilarity, 0.111)
 })
 
+test("inserting an element invalidates the magnitude cache", function () {
+  var vector = new lunr.Vector,
+      elements = [4,5,6]
+
+  elements.forEach(function (el, i) { vector.insert(i, el) })
+
+  equal(vector.magnitude(), Math.sqrt(77))
+
+  vector.insert(3, 7)
+
+  equal(vector.magnitude(), Math.sqrt(126))
+})


### PR DESCRIPTION
A typo in `Vector.magnitude()` was preventing it from returning the cached value