### PR TITLE
Fixed Vector.insert when index of new element is less than first element

### DIFF
--- a/lib/vector.js
+++ b/lib/vector.js
@@ -47,6 +47,11 @@ lunr.Vector.prototype.insert = function (idx, val) {
     return this.length++
   }
 
+  if (idx < list.idx) {
+    this.list = new lunr.Vector.Node (idx, val, list)
+    return this.length++
+  }
+
   var prev = list,
       next = list.next
 

--- a/test/vector_test.js
+++ b/test/vector_test.js
@@ -37,3 +37,15 @@ test("calculating the similarity between two vectors", function () {
   equal(roundedSimilarity, 0.111)
 })
 
+test("inserted elements are kept in index order", function () {
+  var vector = new lunr.Vector,
+      elements = [6,5,4]
+
+  vector.insert(2, 4)
+  vector.insert(1, 5)
+  vector.insert(0, 6)
+
+  equal(vector.list.idx, 0)
+  equal(vector.list.next.idx, 1)
+  equal(vector.list.next.next.idx, 2)
+})


### PR DESCRIPTION
I had an issue with `Index.search()` returning some results with a score of zero. The problem was that it was building a `queryVector` with out-of-order elements (e.g. 55/brazil, 52/brabant, 53/bracknell, 54/bratislava), which turned out to be a bug in the `Vector.insert()` method. The first element inserted could never be preceded by any other elements, leading to the strange order seen above.