### PR TITLE
Skip adding null fieldTokens

### DIFF
--- a/lunr.js
+++ b/lunr.js
@@ -934,7 +934,8 @@ lunr.Index.prototype.add = function (doc, emitEvent) {
     var fieldTokens = this.pipeline.run(lunr.tokenizer(doc[field.name]))
 
     docTokens[field.name] = fieldTokens
-    lunr.SortedSet.prototype.add.apply(allDocumentTokens, fieldTokens)
+    if(doc[field.name])
+      lunr.SortedSet.prototype.add.apply(allDocumentTokens, fieldTokens)
   }, this)
 
   this.documentStore.set(docRef, allDocumentTokens)


### PR DESCRIPTION
If a particular doc doesn't have a field, it will have null tokens, so don't add null to the set to prevent invalid ref later.