### PR TITLE
Bugfix documentVector

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -360,11 +360,14 @@ lunr.Index.prototype.documentVector = function (documentRef) {
       documentVector = new lunr.Vector
 
   for (var i = 0; i < documentTokensLength; i++) {
-    var token = documentTokens.elements[i],
-        tf = this.tokenStore.get(token)[documentRef].tf,
-        idf = this.idf(token)
-
-    documentVector.insert(this.corpusTokens.indexOf(token), tf * idf)
+    var token = documentTokens.elements[i];
+    var tokenData = this.tokenStore.get(token);
+    if(tokenData && tokenData[documentRef])
+    {
+      var tf = tokenData[documentRef].tf;
+      var idf = this.idf(token);
+      documentVector.insert(this.corpusTokens.indexOf(token), tf * idf);
+    }
   };
 
   return documentVector


### PR DESCRIPTION
code assumed object always had property defined in documentRef. When this was not the case it would break the loop.