### PR TITLE
Intersection limits the search way too much

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -328,7 +328,7 @@ lunr.Index.prototype.search = function (query) {
     }, this)
 
   var documentSet = documentSets.reduce(function (memo, set) {
-    return memo.intersect(set)
+    return memo.union(set)
   })
 
   return documentSet


### PR DESCRIPTION
Found a bug that when searching for something like "champions league" both words cancel eachother out through intersection. I do not know if this is really a bug or expected behaviour but after changing it to union it works.