### PR TITLE
Fixed #185 - Replaced array-like String access with ES3 compatible counterpart.

### DIFF
--- a/lib/token_store.js
+++ b/lib/token_store.js
@@ -46,7 +46,7 @@ lunr.TokenStore.load = function (serialisedData) {
  */
 lunr.TokenStore.prototype.add = function (token, doc, root) {
   var root = root || this.root,
-      key = token[0],
+      key = token.charAt(0),
       rest = token.slice(1)
 
   if (!(key in root)) root[key] = {docs: {}}
@@ -76,9 +76,9 @@ lunr.TokenStore.prototype.has = function (token) {
   var node = this.root
 
   for (var i = 0; i < token.length; i++) {
-    if (!node[token[i]]) return false
+    if (!node[token.charAt(i)]) return false
 
-    node = node[token[i]]
+    node = node[token.charAt(i)]
   }
 
   return true
@@ -102,9 +102,9 @@ lunr.TokenStore.prototype.getNode = function (token) {
   var node = this.root
 
   for (var i = 0; i < token.length; i++) {
-    if (!node[token[i]]) return {}
+    if (!node[token.charAt(i)]) return {}
 
-    node = node[token[i]]
+    node = node[token.charAt(i)]
   }
 
   return node
@@ -146,8 +146,8 @@ lunr.TokenStore.prototype.remove = function (token, ref) {
   var node = this.root
 
   for (var i = 0; i < token.length; i++) {
-    if (!(token[i] in node)) return
-    node = node[token[i]]
+    if (!(token.charAt(i) in node)) return
+    node = node[token.charAt(i)]
   }
 
   delete node.docs[ref]
@@ -190,4 +190,3 @@ lunr.TokenStore.prototype.toJSON = function () {
     length: this.length
   }
 }
-


### PR DESCRIPTION
Translated ```token[idx]``` to ES3 compatible ```token.charAt(idx)``` calls.

Unit tests have been executed and are all OK. No new tests have been created nor are required.

This PL fixes case #185 