### PR TITLE
Add support for stored fields and non-indexed fields

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ lunr.Index = function () {
   this._ref = 'id'
   this.pipeline = new lunr.Pipeline
   this.documentStore = new lunr.Store
+  this.fieldStore = {}
   this.tokenStore = new lunr.TokenStore
   this.corpusTokens = new lunr.SortedSet
   this.eventEmitter =  new lunr.EventEmitter
@@ -72,6 +73,7 @@ lunr.Index.load = function (serialisedData) {
   idx._ref = serialisedData.ref
 
   idx.documentStore = lunr.Store.load(serialisedData.documentStore)
+  idx.fieldStore = serialisedData.fieldStore
   idx.tokenStore = lunr.TokenStore.load(serialisedData.tokenStore)
   idx.corpusTokens = lunr.SortedSet.load(serialisedData.corpusTokens)
   idx.pipeline = lunr.Pipeline.load(serialisedData.pipeline)
@@ -94,12 +96,15 @@ lunr.Index.load = function (serialisedData) {
  * should be indexed
  * @param {Number} boost An optional boost that can be applied to terms in this
  * field.
+ * @param {Boolean} index Whether to index this field (defaults to true)
+ * @param {Boolean} store Whether to store this field in the index (defaults to
+ * false)
  * @returns {lunr.Index}
  * @memberOf Index
  */
 lunr.Index.prototype.field = function (fieldName, opts) {
   var opts = opts || {},
-      field = { name: fieldName, boost: opts.boost || 1 }
+      field = { name: fieldName, boost: opts.boost || 1, index: opts.index !== false, store: opts.store || false }
 
   this._fields.push(field)
   return this
@@ -142,21 +147,26 @@ lunr.Index.prototype.add = function (doc, emitEvent) {
   var docTokens = {},
       allDocumentTokens = new lunr.SortedSet,
       docRef = doc[this._ref],
+      fields = {},
       emitEvent = emitEvent === undefined ? true : emitEvent
 
   this._fields.forEach(function (field) {
-    var fieldTokens = this.pipeline.run(lunr.tokenizer(doc[field.name]))
-
-    docTokens[field.name] = fieldTokens
-    lunr.SortedSet.prototype.add.apply(allDocumentTokens, fieldTokens)
+    if (field.index !== false) {
+      var fieldTokens = this.pipeline.run(lunr.tokenizer(doc[field.name]))
+      docTokens[field.name] = fieldTokens
+      lunr.SortedSet.prototype.add.apply(allDocumentTokens, fieldTokens)      
+    }
+    if (field.store) fields[field.name] = doc[field.name]
   }, this)
 
   this.documentStore.set(docRef, allDocumentTokens)
+  this.fieldStore[docRef] = fields
   lunr.SortedSet.prototype.add.apply(this.corpusTokens, allDocumentTokens.toArray())
 
   for (var i = 0; i < allDocumentTokens.length; i++) {
     var token = allDocumentTokens.elements[i]
     var tf = this._fields.reduce(function (memo, field) {
+      if (!docTokens[field.name]) return memo;
       var fieldLength = docTokens[field.name].length
 
       if (!fieldLength) return memo
@@ -199,6 +209,7 @@ lunr.Index.prototype.remove = function (doc, emitEvent) {
   var docTokens = this.documentStore.get(docRef)
 
   this.documentStore.remove(docRef)
+  delete this.fieldStore[docRef]
 
   docTokens.forEach(function (token) {
     this.tokenStore.remove(token, docRef)
@@ -333,7 +344,7 @@ lunr.Index.prototype.search = function (query) {
 
   return documentSet
     .map(function (ref) {
-      return { ref: ref, score: queryVector.similarity(this.documentVector(ref)) }
+      return { ref: ref, score: queryVector.similarity(this.documentVector(ref)), fields: this.fieldStore[ref] }
     }, this)
     .sort(function (a, b) {
       return b.score - a.score
@@ -382,6 +393,7 @@ lunr.Index.prototype.toJSON = function () {
     fields: this._fields,
     ref: this._ref,
     documentStore: this.documentStore.toJSON(),
+    fieldStore: this.fieldStore,
     tokenStore: this.tokenStore.toJSON(),
     corpusTokens: this.corpusTokens.toJSON(),
     pipeline: this.pipeline.toJSON()

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -4,14 +4,28 @@ test("defining what fields to index", function () {
   var idx = new lunr.Index
   idx.field('foo')
 
-  deepEqual(idx._fields[0], {name: 'foo', boost: 1})
+  deepEqual(idx._fields[0], {name: 'foo', boost: 1, index: true, store: false})
 })
 
 test("giving a particular field a weighting", function () {
   var idx = new lunr.Index
   idx.field('foo', { boost: 10 })
 
-  deepEqual(idx._fields[0], {name: 'foo', boost: 10})
+  deepEqual(idx._fields[0], {name: 'foo', boost: 10, index: true, store: false})
+})
+
+test("defining a particular field not to index", function () {
+  var idx = new lunr.Index
+  idx.field('foo', { index: false })
+
+  deepEqual(idx._fields[0], {name: 'foo', boost: 1, index: false, store: false})
+})
+
+test("defining a particular field to store", function () {
+  var idx = new lunr.Index
+  idx.field('foo', { store: true })
+
+  deepEqual(idx._fields[0], {name: 'foo', boost: 1, index: true, store: true})
 })
 
 test('default reference should be id', function () {
@@ -252,11 +266,13 @@ test('silencing update events', function () {
 test('serialising', function () {
   var idx = new lunr.Index,
       mockDocumentStore = { toJSON: function () { return 'documentStore' }},
+      mockFieldStore = 'fieldStore',
       mockTokenStore = { toJSON: function () { return 'tokenStore' }},
       mockCorpusTokens = { toJSON: function () { return 'corpusTokens' }},
       mockPipeline = { toJSON: function () { return 'pipeline' }}
 
   idx.documentStore = mockDocumentStore
+  idx.fieldStore = mockFieldStore
   idx.tokenStore = mockTokenStore
   idx.corpusTokens = mockCorpusTokens
   idx.pipeline = mockPipeline
@@ -269,11 +285,12 @@ test('serialising', function () {
   deepEqual(idx.toJSON(), {
     version: '@VERSION', // this is what the lunr version is set to before being built
     fields: [
-      { name: 'title', boost: 10 },
-      { name: 'body', boost: 1 }
+      { name: 'title', boost: 10, store: false, index: true },
+      { name: 'body', boost: 1, store: false, index: true }
     ],
     ref: 'id',
     documentStore: 'documentStore',
+    fieldStore: 'fieldStore',
     tokenStore: 'tokenStore',
     corpusTokens: 'corpusTokens',
     pipeline: 'pipeline'
@@ -289,6 +306,7 @@ test('loading a serialised index', function () {
     ],
     ref: 'id',
     documentStore: { store: {}, length: 0 },
+    fieldStore: { store: {}, length: 0 },
     tokenStore: { root: {}, length: 0 },
     corpusTokens: [],
     pipeline: ['stopWordFilter', 'stemmer']

--- a/test/search_test.js
+++ b/test/search_test.js
@@ -2,6 +2,7 @@ module('search', {
   setup: function () {
     var idx = new lunr.Index
     idx.field('body')
+    idx.field('wordCount', { store: true, index: false })
     idx.field('title', { boost: 10 })
 
     ;([{
@@ -12,6 +13,7 @@ module('search', {
     },{
       id: 'b',
       title: 'Plumb waters plant',
+      property: 'Suspect',
       body: 'Professor Plumb has a green plant in his study',
       wordCount: 9
     },{
@@ -38,6 +40,7 @@ test('returning the correct results', function () {
 
   equal(results.length, 2)
   equal(results[0].ref, 'b')
+  equal(results[0].fields.wordCount, 9)
 })
 
 test('search term not in the index', function () {
@@ -63,6 +66,7 @@ test('search takes into account boosts', function () {
 
   equal(results.length, 2)
   equal(results[0].ref, 'c')
+  equal(results[0].fields.wordCount, 16)
 
   ok(results[0].score > 10 * results[1].score)
 })
@@ -72,6 +76,7 @@ test('search boosts exact matches', function () {
 
   equal(results.length, 2)
   equal(results[0].ref, 'e')
+  equal(results[0].fields.wordCount, undefined)
 
   ok(results[0].score > results[1].score)
 })


### PR DESCRIPTION
This allows storing fields in the index with our without indexing them in the token store.

Allows you to add attributes that you want returned in the search results.

Example:
```
var index = new lunr.Index()
index.field('url', {store: true, index: false})
index.field('title', {store: true, index: true})
index.field('body')

index.add({
    'id': 1,
    'url': 'http://example.com/getting-started.html',
    'title': 'Getting Started with Lunr.js'
    'body': '...'
});

var results = index.search('lunr');
results.forEach(function(result) {
    console.log('<a href="' + result.fields.url + '">' + results.fields.title + '</a>');
});
```

