### PR TITLE
Protection from "Uncaught RangeError: Maximum call stack size exceeded"

### DIFF
--- a/lib/token_store.js
+++ b/lib/token_store.js
@@ -45,18 +45,19 @@ lunr.TokenStore.load = function (serialisedData) {
  * @memberOf TokenStore
  */
 lunr.TokenStore.prototype.add = function (token, doc, root) {
-  var root = root || this.root,
-      key = token.charAt(0),
-      rest = token.slice(1)
-
-  if (!(key in root)) root[key] = {docs: {}}
-
-  if (rest.length === 0) {
-    root[key].docs[doc.ref] = doc
-    this.length += 1
-    return
-  } else {
-    return this.add(rest, doc, root[key])
+  var root = root || this.root;
+  var tokenArray = token.split('');
+  var tokenArrayLength = tokenArray.length;
+  for (var index = 0; index < tokenArrayLength; ++index) {
+    var element = tokenArray[index];
+    if (!(element in root)) root[element] = { docs: {} };
+    if (index === tokenArrayLength - 1) {
+      root[element].docs[doc.ref] = doc;
+      this.length += 1;
+      return
+    } else {
+      root = root[element];
+    }
   }
 }
 


### PR DESCRIPTION
Seems like big documents have this problem. Add protection from stack recursion. Not very elegant, but works like a charm.
