### PR TITLE
Add closure support

### DIFF
--- a/build/wrapper_start
+++ b/build/wrapper_start
@@ -1,3 +1,7 @@
+if (typeof goog !== 'undefined') {
+    goog.provide('lunr');
+}
+
 /**
  * lunr - http://lunrjs.com - A bit like Solr, but much smaller and not as bright - @VERSION
  * Copyright (C) @YEAR Oliver Nightingale


### PR DESCRIPTION
This PR allows to use lunr.js easilly in closure applications (https://developers.google.com/closure/library/docs/tutorial)
which is used by clojurescript https://github.com/clojure/clojurescript/wiki/Google%20Closure