### PR TITLE
Fixed a problem where a document with lots of tokens causes a RangeError

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,11 +151,15 @@ lunr.Index.prototype.add = function (doc, emitEvent) {
     var fieldTokens = this.pipeline.run(lunr.tokenizer(doc[field.name]))
 
     docTokens[field.name] = fieldTokens
-    lunr.SortedSet.prototype.add.apply(allDocumentTokens, fieldTokens)
+
+    for (var i = 0; i < fieldTokens.length; i++) {
+      var token = fieldTokens[i]
+      allDocumentTokens.add(token)
+      this.corpusTokens.add(token)
+    }
   }, this)
 
   this.documentStore.set(docRef, allDocumentTokens)
-  lunr.SortedSet.prototype.add.apply(this.corpusTokens, allDocumentTokens.toArray())
 
   for (var i = 0; i < allDocumentTokens.length; i++) {
     var token = allDocumentTokens.elements[i]

--- a/lib/sorted_set.js
+++ b/lib/sorted_set.js
@@ -224,7 +224,9 @@ lunr.SortedSet.prototype.union = function (otherSet) {
 
   unionSet = longSet.clone()
 
-  unionSet.add.apply(unionSet, shortSet.toArray())
+  for(var i = 0, shortSetElements = shortSet.toArray(); i < shortSetElements.length; i++){
+    unionSet.add(shortSetElements[i]);
+  }
 
   return unionSet
 }

--- a/lunr.js
+++ b/lunr.js
@@ -608,14 +608,14 @@ lunr.SortedSet.load = function (serialisedData) {
  * Inserts new items into the set in the correct position to maintain the
  * order.
  *
- * @param {Array} inputObjects The objects to add to this set.
+ * @param {Object} The objects to add to this set.
  * @memberOf SortedSet
  */
-lunr.SortedSet.prototype.add = function (inputObjects) {
+lunr.SortedSet.prototype.add = function () {
   var i, element
 
-  for (i = 0; i < inputObjects.length; i++) {
-    element = inputObjects[i]
+  for (i = 0; i < arguments.length; i++) {
+    element = arguments[i]
     if (~this.indexOf(element)) continue
     this.elements.splice(this.locationFor(element), 0, element)
   }
@@ -745,7 +745,7 @@ lunr.SortedSet.prototype.intersect = function (otherSet) {
     if (i > a_len - 1 || j > b_len - 1) break
 
     if (a[i] === b[j]) {
-      intersectSet.add([a[i]])
+      intersectSet.add(a[i])
       i++, j++
       continue
     }
@@ -798,7 +798,7 @@ lunr.SortedSet.prototype.union = function (otherSet) {
 
   unionSet = longSet.clone()
 
-  unionSet.add(shortSet.toArray())
+  unionSet.add.apply(unionSet, shortSet.toArray())
 
   return unionSet
 }
@@ -963,12 +963,13 @@ lunr.Index.prototype.add = function (doc, emitEvent) {
 
   this._fields.forEach(function (field) {
     var fieldTokens = this.pipeline.run(lunr.tokenizer(doc[field.name]))
+
     docTokens[field.name] = fieldTokens
-    allDocumentTokens.add(fieldTokens)
+    lunr.SortedSet.prototype.add.apply(allDocumentTokens, fieldTokens)
   }, this)
 
   this.documentStore.set(docRef, allDocumentTokens)
-  this.corpusTokens.add(allDocumentTokens.toArray())
+  lunr.SortedSet.prototype.add.apply(this.corpusTokens, allDocumentTokens.toArray())
 
   for (var i = 0; i < allDocumentTokens.length; i++) {
     var token = allDocumentTokens.elements[i]
@@ -1141,7 +1142,7 @@ lunr.Index.prototype.search = function (query) {
             refsLen = refs.length
 
         for (var i = 0; i < refsLen; i++) {
-          set.add([matchingDocuments[refs[i]].ref])
+          set.add(matchingDocuments[refs[i]].ref)
         }
 
         return memo.union(set)

--- a/lunr.js
+++ b/lunr.js
@@ -608,14 +608,14 @@ lunr.SortedSet.load = function (serialisedData) {
  * Inserts new items into the set in the correct position to maintain the
  * order.
  *
- * @param {Object} The objects to add to this set.
+ * @param {Array} inputObjects The objects to add to this set.
  * @memberOf SortedSet
  */
-lunr.SortedSet.prototype.add = function () {
+lunr.SortedSet.prototype.add = function (inputObjects) {
   var i, element
 
-  for (i = 0; i < arguments.length; i++) {
-    element = arguments[i]
+  for (i = 0; i < inputObjects.length; i++) {
+    element = inputObjects[i]
     if (~this.indexOf(element)) continue
     this.elements.splice(this.locationFor(element), 0, element)
   }
@@ -745,7 +745,7 @@ lunr.SortedSet.prototype.intersect = function (otherSet) {
     if (i > a_len - 1 || j > b_len - 1) break
 
     if (a[i] === b[j]) {
-      intersectSet.add(a[i])
+      intersectSet.add([a[i]])
       i++, j++
       continue
     }
@@ -798,7 +798,7 @@ lunr.SortedSet.prototype.union = function (otherSet) {
 
   unionSet = longSet.clone()
 
-  unionSet.add.apply(unionSet, shortSet.toArray())
+  unionSet.add(shortSet.toArray())
 
   return unionSet
 }
@@ -963,13 +963,12 @@ lunr.Index.prototype.add = function (doc, emitEvent) {
 
   this._fields.forEach(function (field) {
     var fieldTokens = this.pipeline.run(lunr.tokenizer(doc[field.name]))
-
     docTokens[field.name] = fieldTokens
-    lunr.SortedSet.prototype.add.apply(allDocumentTokens, fieldTokens)
+    allDocumentTokens.add(fieldTokens)
   }, this)
 
   this.documentStore.set(docRef, allDocumentTokens)
-  lunr.SortedSet.prototype.add.apply(this.corpusTokens, allDocumentTokens.toArray())
+  this.corpusTokens.add(allDocumentTokens.toArray())
 
   for (var i = 0; i < allDocumentTokens.length; i++) {
     var token = allDocumentTokens.elements[i]

--- a/lunr.js
+++ b/lunr.js
@@ -1141,7 +1141,7 @@ lunr.Index.prototype.search = function (query) {
             refsLen = refs.length
 
         for (var i = 0; i < refsLen; i++) {
-          set.add(matchingDocuments[refs[i]].ref)
+          set.add([matchingDocuments[refs[i]].ref])
         }
 
         return memo.union(set)


### PR DESCRIPTION
Before this fix, the index passed all tokens via an apply call, pushing all parameters on the stack.
This behaviour causes a RangeError when more tokens are added than the JS implementation can handle.

This fix changes the code so that now an explicit Array is passed instead of pushing the values of the array on the stack.

Some Tests on the maximum Stack size using the suggested method from http://stackoverflow.com/questions/22747068/is-there-a-max-number-of-arguments-javascript-functions-can-accept:
* Firefox v44: >= 262143
* Node.js: >= 65535