### PR TITLE
Refactored all add() calls from SortedSet to only pass single values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,11 +151,15 @@ lunr.Index.prototype.add = function (doc, emitEvent) {
     var fieldTokens = this.pipeline.run(lunr.tokenizer(doc[field.name]))
 
     docTokens[field.name] = fieldTokens
-    lunr.SortedSet.prototype.add.apply(allDocumentTokens, fieldTokens)
+
+    for (var i = 0; i < fieldTokens.length; i++) {
+      var token = fieldTokens[i]
+      allDocumentTokens.add(token)
+      this.corpusTokens.add(token)
+    }
   }, this)
 
   this.documentStore.set(docRef, allDocumentTokens)
-  lunr.SortedSet.prototype.add.apply(this.corpusTokens, allDocumentTokens.toArray())
 
   for (var i = 0; i < allDocumentTokens.length; i++) {
     var token = allDocumentTokens.elements[i]

--- a/lib/sorted_set.js
+++ b/lib/sorted_set.js
@@ -224,7 +224,9 @@ lunr.SortedSet.prototype.union = function (otherSet) {
 
   unionSet = longSet.clone()
 
-  unionSet.add.apply(unionSet, shortSet.toArray())
+  for(var i = 0, shortSetElements = shortSet.toArray(); i < shortSetElements.length; i++){
+    unionSet.add(shortSetElements[i]);
+  }
 
   return unionSet
 }

--- a/lib/sorted_set.js
+++ b/lib/sorted_set.js
@@ -225,7 +225,7 @@ lunr.SortedSet.prototype.union = function (otherSet) {
   unionSet = longSet.clone()
 
   for(var i = 0, shortSetElements = shortSet.toArray(); i < shortSetElements.length; i++){
-    unionSet.add(shortSetElements[i]);
+    unionSet.add(shortSetElements[i])
   }
 
   return unionSet


### PR DESCRIPTION
Before this fix, the index passed all tokens via an apply call, pushing all parameters on the stack.

This behaviour causes a RangeError when more tokens are added than the JS implementation can handle (Firefox 44 -> 262143, Node.js -> 65535, evaluated using this test: http://stackoverflow.com/questions/22747068/is-there-a-max-number-of-arguments-javascript-functions-can-accept)
this fix changes the code so that now only a single value gets passed per call. This way no change to the current API is neccesary.

The code was refactored in a way that it now passes only a single argument at a time, avoiding the usage of apply.

The only parts of the code that still use apply are the EventEmitters and the Plugin subsystem which should be non critical for this type of error.