### PR TITLE
Make tokenizer a property of an index.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ lunr.Index = function () {
   this.tokenStore = new lunr.TokenStore
   this.corpusTokens = new lunr.SortedSet
   this.eventEmitter =  new lunr.EventEmitter
+  this.tokenizerFn = lunr.tokenizer
 
   this._idfCache = {}
 
@@ -71,6 +72,7 @@ lunr.Index.load = function (serialisedData) {
   idx._fields = serialisedData.fields
   idx._ref = serialisedData.ref
 
+  idx.tokenizer = lunr.tokenizer.load(serialisedData.tokenizer)
   idx.documentStore = lunr.Store.load(serialisedData.documentStore)
   idx.tokenStore = lunr.TokenStore.load(serialisedData.tokenStore)
   idx.corpusTokens = lunr.SortedSet.load(serialisedData.corpusTokens)
@@ -126,6 +128,16 @@ lunr.Index.prototype.ref = function (refName) {
   return this
 }
 
+lunr.Index.prototype.tokenizer = function (fn) {
+  var isRegistered = fn.label && (fn.label in lunr.tokenizer.registeredFunctions)
+
+  if (!isRegistered) {
+    lunr.utils.warn('Function is not a registered tokenizer. This may cause problems when serialising the index')
+  }
+
+  this.tokenizerFn = fn
+}
+
 /**
  * Add a document to the index.
  *
@@ -148,7 +160,7 @@ lunr.Index.prototype.add = function (doc, emitEvent) {
       emitEvent = emitEvent === undefined ? true : emitEvent
 
   this._fields.forEach(function (field) {
-    var fieldTokens = this.pipeline.run(lunr.tokenizer(doc[field.name]))
+    var fieldTokens = this.pipeline.run(this.tokenizerFn(doc[field.name]))
 
     docTokens[field.name] = fieldTokens
     lunr.SortedSet.prototype.add.apply(allDocumentTokens, fieldTokens)
@@ -286,7 +298,7 @@ lunr.Index.prototype.idf = function (term) {
  * @memberOf Index
  */
 lunr.Index.prototype.search = function (query) {
-  var queryTokens = this.pipeline.run(lunr.tokenizer(query)),
+  var queryTokens = this.pipeline.run(this.tokenizerFn(query)),
       queryVector = new lunr.Vector,
       documentSets = [],
       fieldBoosts = this._fields.reduce(function (memo, f) { return memo + f.boost }, 0)
@@ -391,6 +403,7 @@ lunr.Index.prototype.toJSON = function () {
     version: lunr.version,
     fields: this._fields,
     ref: this._ref,
+    tokenizer: this.tokenizerFn.label,
     documentStore: this.documentStore.toJSON(),
     tokenStore: this.tokenStore.toJSON(),
     corpusTokens: this.corpusTokens.toJSON(),

--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -28,3 +28,28 @@ lunr.tokenizer = function (obj) {
  * @see lunr.tokenizer
  */
 lunr.tokenizer.seperator = /[\s\-]+/
+
+lunr.tokenizer.load = function (label) {
+  var fn = this.registeredFunctions[label]
+
+  if (!fn) {
+    throw new Error('Cannot load un-registered function: ' + label)
+  }
+
+  return fn
+}
+
+lunr.tokenizer.label = 'default'
+
+lunr.tokenizer.registeredFunctions = {
+  'default': lunr.tokenizer
+}
+
+lunr.tokenizer.registerFunction = function (fn, label) {
+  if (label in this.registeredFunctions) {
+    lunr.utils.warn('Overwriting existing tokenizer: ' + label)
+  }
+
+  fn.label = label
+  this.registeredFunctions[label] = fn
+}

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -26,6 +26,21 @@ test("defining the reference field for the index", function () {
   deepEqual(idx._ref, 'foo')
 })
 
+test("default tokenizer should be the lunr.tokenizer", function () {
+  var idx = new lunr.Index
+  equal(idx.tokenizerFn, lunr.tokenizer)
+})
+
+test("using a custom tokenizer", function () {
+  var idx = new lunr.Index,
+      fn = function () {}
+
+  lunr.tokenizer.registerFunction(fn, 'test')
+
+  idx.tokenizer(fn)
+  equal(idx.tokenizerFn, fn)
+})
+
 test('adding a document to the index', function () {
   var idx = new lunr.Index,
       doc = {id: 1, body: 'this is a test'}
@@ -276,7 +291,8 @@ test('serialising', function () {
     documentStore: 'documentStore',
     tokenStore: 'tokenStore',
     corpusTokens: 'corpusTokens',
-    pipeline: 'pipeline'
+    pipeline: 'pipeline',
+    tokenizer: 'default'
   })
 })
 
@@ -291,7 +307,8 @@ test('loading a serialised index', function () {
     documentStore: { store: {}, length: 0 },
     tokenStore: { root: {}, length: 0 },
     corpusTokens: [],
-    pipeline: ['stopWordFilter', 'stemmer']
+    pipeline: ['stopWordFilter', 'stemmer'],
+    tokenizer: 'default'
   }
 
   var idx = lunr.Index.load(serialisedData)

--- a/test/tokenizer_test.js
+++ b/test/tokenizer_test.js
@@ -70,3 +70,28 @@ test("splitting strings with hyphens and spaces", function () {
 
   deepEqual(tokens, ['solve', 'for', 'a', 'b'])
 })
+
+test("registering a tokenizer function", function () {
+  var fn = function () {}
+  lunr.tokenizer.registerFunction(fn, 'test')
+
+  equal(fn.label, 'test')
+  equal(lunr.tokenizer.registeredFunctions['test'], fn)
+
+  delete lunr.tokenizer.registerFunction['test'] // resetting the state after the test
+})
+
+test("loading a registered tokenizer", function () {
+  var serialized = 'default', // default tokenizer is already registered
+      tokenizerFn = lunr.tokenizer.load(serialized)
+
+  equal(tokenizerFn, lunr.tokenizer)
+})
+
+test("loading an un-registered tokenizer", function () {
+  var serialized = 'un-registered' // default tokenizer is already registered
+
+  throws(function () {
+    lunr.tokenizer.load(serialized)
+  })
+})


### PR DESCRIPTION
Before this change the tokenizer was a global property of lunr, every
index would use the same tokenizer. It was possible to change the
tokenizer but not on a per index basis.

This change gives each instance of lunr.Index its own tokenzier,
defaulting to the existing lunr.tokenizer implementation. Each index can
change the tokenizer it uses without affecting any other index instance.

To ensure that indexes with custom tokenizers can be serialied and
de-serialised custom tokenizers can be regsitered in much the same way
as a custom text processing function is registered in lunr.Pipeline.

I still need to add documentation for this new feature, opening a pr to get feedback from @metmajer and @mjrussell who requested this feature in #21 