### PR TITLE
Rename tokenizer.seperator to separator

### DIFF
--- a/lib/tokenizer.js
+++ b/lib/tokenizer.js
@@ -5,29 +5,45 @@
 
 /**
  * A function for splitting a string into tokens ready to be inserted into
- * the search index. Uses `lunr.tokenizer.seperator` to split strings, change
+ * the search index. Uses `lunr.tokenizer.separator` to split strings, change
  * the value of this property to change how strings are split into tokens.
  *
  * @module
  * @param {String} obj The string to convert into tokens
- * @see lunr.tokenizer.seperator
+ * @see lunr.tokenizer.separator
  * @returns {Array}
  */
 lunr.tokenizer = function (obj) {
   if (!arguments.length || obj == null || obj == undefined) return []
   if (Array.isArray(obj)) return obj.map(function (t) { return lunr.utils.asString(t).toLowerCase() })
 
-  return obj.toString().trim().toLowerCase().split(lunr.tokenizer.seperator)
+  return obj.toString().trim().toLowerCase().split(lunr.tokenizer.separator)
 }
 
 /**
- * The sperator used to split a string into tokens. Override this property to change the behaviour of
+ * Define a get and set method for seperator [sic], to add legacy support for the misspelling of
+ * separator. Use lunr.tokenizer.separator instead.
+ *
+ * @see lunr.tokenizer.separator
+ * @deprecated since 0.8.0
+ */
+Object.defineProperty(lunr.tokenizer, "seperator", {
+  get: function (){
+    return this.separator
+  },
+  set: function (val){
+    return this.separator = val
+  }
+})
+
+/**
+ * The separator used to split a string into tokens. Override this property to change the behaviour of
  * `lunr.tokenizer` behaviour when tokenizing strings. By default this splits on whitespace and hyphens.
  *
  * @static
  * @see lunr.tokenizer
  */
-lunr.tokenizer.seperator = /[\s\-]+/
+lunr.tokenizer.separator = /[\s\-]+/
 
 /**
  * Loads a previously serialised tokenizer.

--- a/test/tokenizer_test.js
+++ b/test/tokenizer_test.js
@@ -95,3 +95,18 @@ test("loading an un-registered tokenizer", function () {
     lunr.tokenizer.load(serialized)
   })
 })
+
+test("using the seperator alias", function(){
+
+  // Check they are equal at the start
+  equal(lunr.tokenizer.seperator, lunr.tokenizer.separator)
+
+  // Update via the correct spelling and verify.
+  lunr.tokenizer.separator = /[\s]+/
+  equal(lunr.tokenizer.seperator, lunr.tokenizer.separator)
+
+  // Update via the incorrect spelling and verify.
+  lunr.tokenizer.seperator = /[\s\-]+/
+  equal(lunr.tokenizer.seperator, lunr.tokenizer.separator)
+
+})


### PR DESCRIPTION
This change includes an alias to handle backwards compatibility.

Fixes #206
