### PR TITLE
Only include lunr.js in package.json files property.

### DIFF
--- a/build/package.json.template
+++ b/build/package.json.template
@@ -6,6 +6,9 @@
   "keywords": ["search"],
   "homepage": "http://lunrjs.com",
   "bugs": "http://github.com/olivernn/lunr.js/issues",
+  "files": [
+    "lunr.js"
+  ],
   "main": "lunr.js",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Since you're building the `lunr.js` file and using it as the main file in node, it's the only one that needs to be published to npm.