### PR TITLE
generate sourcemap with minified version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lunr.js: $(SRC)
 	sed "s/@VERSION/${VERSION}/" > $@
 
 lunr.min.js: lunr.js
-	${UGLIFYJS} --compress --mangle --comments < $< > $@
+	${UGLIFYJS} --compress --mangle --comments --source-map lunr.map lunr.js > $@
 
 %.json: build/%.json.template
 	cat $< | sed "s/@VERSION/${VERSION}/" > $@


### PR DESCRIPTION
UglifyJS supports sourcemap generation. Add sourcemap `lunr.map` at the root of the directory when generating `lunr.min.js`

I had to remove the input file to uglifyjs as STDIN because in that case, sourcemap generation is unsupported .
cf : https://github.com/mishoo/UglifyJS2/blob/master/bin/uglifyjs#L301