### PR TITLE
separate search and score sorting operation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -322,7 +322,7 @@ lunr.Index.prototype.idf = function (term) {
  * @see Index.prototype.documentVector
  * @memberOf Index
  */
-lunr.Index.prototype.search = function (query) {
+lunr.Index.prototype.baseSearch = function (query) {
   var queryTokens = this.pipeline.run(this.tokenizerFn(query)),
       queryVector = new lunr.Vector,
       documentSets = [],
@@ -382,6 +382,19 @@ lunr.Index.prototype.search = function (query) {
     .map(function (ref) {
       return { ref: ref, score: queryVector.similarity(this.documentVector(ref)) }
     }, this)
+}
+
+/**
+ * Searches the index using the passed query and returns result sorted by score.
+ *
+ * @param {String} query The query to search the index with.
+ * @returns {Object}
+ * @see Index.prototype.baseSearch
+ * @memberOf Index
+ */
+lunr.Index.prototype.search = function (query) {
+  return this
+    .search(query)
     .sort(function (a, b) {
       return b.score - a.score
     })


### PR DESCRIPTION
This pull request proposes to separate the search operation in a `baseSearch` method to give the ability to get the search results without always sorting by score.