### PR TITLE
Update token_store.js

### DIFF
--- a/lib/token_store.js
+++ b/lib/token_store.js
@@ -80,7 +80,7 @@ lunr.TokenStore.prototype.has = function (token) {
 
     node = node[token.charAt(i)]
   }
-
+  for (key in node) if (key != 'docs') return false
   return true
 }
 


### PR DESCRIPTION
fixed issue that caused search to be a prefix search on the data iso. a literal equality
(eg. search for 'redis' returns a hit for documents containing 'redirect')