### PR TITLE
Add support for adding wildcards to clause term

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -14,6 +14,11 @@ lunr.Query = function (allFields) {
   this.allFields = allFields
 }
 
+lunr.Query.wildcard = new String ("*")
+lunr.Query.wildcard.NONE = 0
+lunr.Query.wildcard.LEADING = 1
+lunr.Query.wildcard.TRAILING = 2
+
 /**
  * A single clause in a {@link lunr.Query} contains a term and details on how to
  * match that term against a {@link lunr.Index}.
@@ -45,6 +50,18 @@ lunr.Query.prototype.clause = function (clause) {
 
   if (!('usePipeline' in clause)) {
     clause.usePipeline = true
+  }
+
+  if (!('wildcard' in clause)) {
+    clause.wildcard = lunr.Query.wildcard.NONE
+  }
+
+  if ((clause.wildcard & lunr.Query.wildcard.LEADING) && (clause.term.charAt(0) != lunr.Query.wildcard)) {
+    clause.term = "*" + clause.term
+  }
+
+  if ((clause.wildcard & lunr.Query.wildcard.TRAILING) && (clause.term.slice(-1) != lunr.Query.wildcard)) {
+    clause.term = "" + clause.term + "*"
   }
 
   this.clauses.push(clause)

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -49,5 +49,82 @@ suite('lunr.Query', function () {
         assert.isFalse(this.clause.usePipeline)
       })
     })
+
+    suite('wildcards', function () {
+      suite('none', function () {
+        setup(function () {
+          this.query.clause({
+            term: 'foo',
+            wildcard: lunr.Query.wildcard.NONE
+          })
+
+          this.clause = this.query.clauses[0]
+        })
+
+        test('no wildcard', function () {
+          assert.equal(this.clause.term, 'foo')
+        })
+      })
+
+      suite('leading', function () {
+        setup(function () {
+          this.query.clause({
+            term: 'foo',
+            wildcard: lunr.Query.wildcard.LEADING
+          })
+
+          this.clause = this.query.clauses[0]
+        })
+
+        test('adds wildcard', function () {
+          assert.equal(this.clause.term, '*foo')
+        })
+      })
+
+      suite('trailing', function () {
+        setup(function () {
+          this.query.clause({
+            term: 'foo',
+            wildcard: lunr.Query.wildcard.TRAILING
+          })
+
+          this.clause = this.query.clauses[0]
+        })
+
+        test('adds wildcard', function () {
+          assert.equal(this.clause.term, 'foo*')
+        })
+      })
+
+      suite('leading and trailing', function () {
+        setup(function () {
+          this.query.clause({
+            term: 'foo',
+            wildcard: lunr.Query.wildcard.TRAILING | lunr.Query.wildcard.LEADING
+          })
+
+          this.clause = this.query.clauses[0]
+        })
+
+        test('adds wildcards', function () {
+          assert.equal(this.clause.term, '*foo*')
+        })
+      })
+
+      suite('existing', function () {
+        setup(function () {
+          this.query.clause({
+            term: '*foo*',
+            wildcard: lunr.Query.wildcard.TRAILING | lunr.Query.wildcard.LEADING
+          })
+
+          this.clause = this.query.clauses[0]
+        })
+
+        test('no additional wildcards', function () {
+          assert.equal(this.clause.term, '*foo*')
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
Adds an option when creating a query for specifying wildcard matching. Previously there was no provided support for this, which meant that if creating queries programatically the wildcards would have to be manually added, e.g.

```javascript
var someQueryTerm = "whatever"

idx.query(function (q) {
  q.term(someQueryTerm + "*")
})
```

Instead this could now be achieved with the following:

```javascript
var someQueryTerm = "whatever"

idx.query(function (q) {
  q.term(someQueryTerm, { wildcard: lunr.Query.wildcard.TRAILING })
})
```

This is a bit cleaner as well as handling cases where there is already a trailing wildcard.

Wildcards are controlled by flags which can be combined to add leading and trailing wildcards, e.g.

```javascript
q.term(someQueryTerm, { wildcard: lunr.Query.wildcard.LEADING | lunr.Query.wildcard.TRAILING })
```

Questions:
* Does this interface provide enough support for adding wildcards when programatically building a query?
* Are there any other ways of inserting wildcards that should be support?
* Does the interface _prevent_ any extensions in the future (it shouldn't)?