### PR TITLE
update bower.json to real version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "lunr.js",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "main": "lunr.js",
   "ignore": [
     "tests/",


### PR DESCRIPTION
fixes "bower lunr.js#2.1 mismatch Version declared in the json (1.0.0) is different than the resolved one (2.1.0)"  warning when installing. 

Bower is not a thing of the future any more, but will stick around long enough to support it.   This is just a cosmetic fix (bower is still fetching the right version). 