### PR TITLE
Use prototype free object for `fieldTerms` hash

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -125,7 +125,7 @@ lunr.Builder.prototype.add = function (doc) {
         tokens = this.tokenizer(field),
         terms = this.pipeline.run(tokens),
         fieldRef = new lunr.FieldRef (docRef, fieldName),
-        fieldTerms = {}
+        fieldTerms = Object.create(null)
 
     this.fieldTermFrequencies[fieldRef] = fieldTerms
     this.fieldLengths[fieldRef] = 0

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -10,6 +10,8 @@ suite('lunr.Builder', function () {
 
       assert.deepProperty(this.builder.invertedIndex, 'constructor.title.id')
       assert.deepEqual(this.builder.invertedIndex.constructor.title.id, {})
+
+      assert.equal(this.builder.fieldTermFrequencies['title/id'].constructor, 1)
     })
 
     test('field name clashes with object prototype', function () {


### PR DESCRIPTION
Previously terms that collided with standard Object properties we breaking
the calculation of frequencies - leading to NaN scores for queries.

Fixes #280 