### PR TITLE
Throw proper error if non-function is added to the pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -81,14 +81,18 @@ lunr.Pipeline.registerFunction = function (fn, label) {
 }
 
 /**
+ * Throws an error if the argument passed is not a function.
  * Warns if the function is not registered as a Pipeline function.
  *
  * @param {lunr.PipelineFunction} fn - The function to check for.
  * @private
  */
-lunr.Pipeline.warnIfFunctionNotRegistered = function (fn) {
-  var isRegistered = fn.label && (fn.label in this.registeredFunctions)
+lunr.Pipeline.checkPipelineFunction = function (fn) {
+  if ( !(fn instanceof Function) ) {
+    throw new Error('fn is not a function')
+  }
 
+  var isRegistered = fn.label && (fn.label in this.registeredFunctions)
   if (!isRegistered) {
     lunr.utils.warn('Function is not registered with pipeline. This may cause problems when serialising the index.\n', fn)
   }
@@ -131,7 +135,7 @@ lunr.Pipeline.prototype.add = function () {
   var fns = Array.prototype.slice.call(arguments)
 
   fns.forEach(function (fn) {
-    lunr.Pipeline.warnIfFunctionNotRegistered(fn)
+    lunr.Pipeline.checkPipelineFunction(fn)
     this._stack.push(fn)
   }, this)
 }
@@ -146,7 +150,7 @@ lunr.Pipeline.prototype.add = function () {
  * @param {lunr.PipelineFunction} newFn - The new function to add to the pipeline.
  */
 lunr.Pipeline.prototype.after = function (existingFn, newFn) {
-  lunr.Pipeline.warnIfFunctionNotRegistered(newFn)
+  lunr.Pipeline.checkPipelineFunction(newFn)
 
   var pos = this._stack.indexOf(existingFn)
   if (pos == -1) {
@@ -167,7 +171,7 @@ lunr.Pipeline.prototype.after = function (existingFn, newFn) {
  * @param {lunr.PipelineFunction} newFn - The new function to add to the pipeline.
  */
 lunr.Pipeline.prototype.before = function (existingFn, newFn) {
-  lunr.Pipeline.warnIfFunctionNotRegistered(newFn)
+  lunr.Pipeline.checkPipelineFunction(newFn)
 
   var pos = this._stack.indexOf(existingFn)
   if (pos == -1) {
@@ -249,7 +253,7 @@ lunr.Pipeline.prototype.reset = function () {
  */
 lunr.Pipeline.prototype.toJSON = function () {
   return this._stack.map(function (fn) {
-    lunr.Pipeline.warnIfFunctionNotRegistered(fn)
+    lunr.Pipeline.checkPipelineFunction(fn)
 
     return fn.label
   })


### PR DESCRIPTION
If someone tries to add a non-function to the pipeline (e.g., because someone typed `this.pipeline.add(lunr.stopWorFilter)` - not that this would ever happen to me :wink:), a rather unfriendly error is thrown: `lunr.js:363 Uncaught TypeError: Cannot read property 'label' of undefined`.

This commit produces a specific error and renames the `warnIfFunctionNotRegistered` method to `checkPipelineFunction` in order to reflect the slightly enhanced behaviour.