### PR TITLE
First attempt at mutable indexes for lunr.js 2.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ SRC = lib/lunr.js \
 	lib/query_parse_error.js \
 	lib/query_lexer.js \
 	lib/query_parser.js \
+	lib/mutable_index.js \
+	lib/mutable_builder.js \
 
 YEAR = $(shell date +%Y)
 VERSION = $(shell cat VERSION)

--- a/lib/mutable_builder.js
+++ b/lib/mutable_builder.js
@@ -39,3 +39,38 @@ lunr.MutableBuilder.prototype.remove = function remove (doc) {
     }
   }
 }
+
+lunr.MutableBuilder.prototype.toJSON = function toJSON () {
+  // XXX omit tokenizer for now
+  return {
+    _ref: this._ref,
+    _fields: this._fields,
+    invertedIndex: this.invertedIndex,
+    fieldTermFrequencies: this.fieldTermFrequencies,
+    fieldLengths: this.fieldLengths,
+    pipeline: this.pipeline.toJSON(),
+    searchPipeline: this.searchPipeline.toJSON(),
+    documentCount: this.documentCount,
+    _b: this._b, // XXX special (due to precision)?
+    _k1: this._k1, // XXX special (due to precision)?
+    termIndex: this.termIndex,
+    metadataWhitelist: this.metadataWhitelist
+  }
+}
+
+lunr.MutableBuilder.load = function load (serializedBuilder) {
+  var builder = new lunr.MutableBuilder()
+
+  for (var k in serializedBuilder) {
+    if (serializedBuilder.hasOwnProperty(k)) {
+      builder[k] = serializedBuilder[k]
+    }
+  }
+
+  // builder.tokenizer is initialized to the default by the MutableBuilder
+  // constructor
+  builder.pipeline = lunr.Pipeline.load(builder.pipeline)
+  builder.searchPipeline = lunr.Pipeline.load(builder.searchPipeline)
+
+  return builder
+}

--- a/lib/mutable_builder.js
+++ b/lib/mutable_builder.js
@@ -1,0 +1,41 @@
+lunr.MutableBuilder = function () {
+  lunr.Builder.call(this)
+}
+
+lunr.MutableBuilder.prototype = new lunr.Builder()
+
+lunr.MutableBuilder.prototype.build = function build () {
+  this.calculateAverageFieldLengths()
+  this.createFieldVectors()
+  this.createTokenSet()
+
+  return new lunr.MutableIndex({
+    invertedIndex: this.invertedIndex,
+    fieldVectors: this.fieldVectors,
+    tokenSet: this.tokenSet,
+    fields: this._fields,
+    pipeline: this.searchPipeline,
+    builder: this
+  })
+}
+
+lunr.MutableBuilder.prototype.remove = function remove (doc) {
+  var docRef = doc[this._ref]
+
+  this.documentCount -= 1
+
+  for (var i = 0; i < this._fields.length; i++) {
+    var fieldName = this._fields[i],
+        fieldRef = new lunr.FieldRef (docRef, fieldName)
+
+    delete this.fieldTermFrequencies[fieldRef]
+    delete this.fieldLengths[fieldRef]
+  }
+
+  // XXX what if a term disappears from the index?
+  for (var term in this.invertedIndex) {
+    for (var fieldName in this.invertedIndex[term]) { // XXX what about "_index"?
+      delete this.invertedIndex[term][fieldName][docRef]
+    }
+  }
+}

--- a/lib/mutable_builder.js
+++ b/lib/mutable_builder.js
@@ -41,14 +41,27 @@ lunr.MutableBuilder.prototype.remove = function remove (doc) {
 }
 
 lunr.MutableBuilder.prototype.toJSON = function toJSON () {
+  var fieldRefs = []
+  var fieldTermFrequencies = []
+  var fieldLengths = []
+
+  for (var fieldRef in this.fieldTermFrequencies) {
+    if (this.fieldTermFrequencies.hasOwnProperty(fieldRef)) {
+      fieldRefs.push(fieldRef)
+      fieldTermFrequencies.push(this.fieldTermFrequencies[fieldRef])
+      fieldLengths.push(this.fieldLengths[fieldRef])
+    }
+  }
+
   // XXX omit tokenizer for now
   // some properties (_fields, invertedIndex, searchPipeline) are omitted
   // from here because they're on the index, and serializing them twice
   // would be redundant
   return {
     _ref: this._ref,
-    fieldTermFrequencies: this.fieldTermFrequencies,
-    fieldLengths: this.fieldLengths,
+    fieldRefs: fieldRefs,
+    fieldTermFrequencies: fieldTermFrequencies,
+    fieldLengths: fieldLengths,
     pipeline: this.pipeline.toJSON(),
     documentCount: this.documentCount,
     _b: this._b, // XXX special (due to precision)?
@@ -65,6 +78,20 @@ lunr.MutableBuilder.load = function load (serializedBuilder) {
     if (serializedBuilder.hasOwnProperty(k)) {
       builder[k] = serializedBuilder[k]
     }
+  }
+
+  var fieldRefs = builder.fieldRefs
+  var fieldTermFrequencies = builder.fieldTermFrequencies
+  var fieldLengths = builder.fieldLengths
+  delete builder.fieldRefs
+
+  builder.fieldTermFrequencies = {}
+  builder.fieldLengths = {}
+
+  for (var i = 0; i < fieldRefs.length; i++) {
+    var fieldRef = fieldRefs[i]
+    builder.fieldTermFrequencies[fieldRef] = fieldTermFrequencies[i]
+    builder.fieldLengths[fieldRef] = fieldLengths[i]
   }
 
   // builder.tokenizer is initialized to the default by the MutableBuilder

--- a/lib/mutable_builder.js
+++ b/lib/mutable_builder.js
@@ -42,14 +42,14 @@ lunr.MutableBuilder.prototype.remove = function remove (doc) {
 
 lunr.MutableBuilder.prototype.toJSON = function toJSON () {
   // XXX omit tokenizer for now
+  // some properties (_fields, invertedIndex, searchPipeline) are omitted
+  // from here because they're on the index, and serializing them twice
+  // would be redundant
   return {
     _ref: this._ref,
-    _fields: this._fields,
-    invertedIndex: this.invertedIndex,
     fieldTermFrequencies: this.fieldTermFrequencies,
     fieldLengths: this.fieldLengths,
     pipeline: this.pipeline.toJSON(),
-    searchPipeline: this.searchPipeline.toJSON(),
     documentCount: this.documentCount,
     _b: this._b, // XXX special (due to precision)?
     _k1: this._k1, // XXX special (due to precision)?
@@ -70,7 +70,6 @@ lunr.MutableBuilder.load = function load (serializedBuilder) {
   // builder.tokenizer is initialized to the default by the MutableBuilder
   // constructor
   builder.pipeline = lunr.Pipeline.load(builder.pipeline)
-  builder.searchPipeline = lunr.Pipeline.load(builder.searchPipeline)
 
   return builder
 }

--- a/lib/mutable_index.js
+++ b/lib/mutable_index.js
@@ -1,0 +1,38 @@
+lunr.MutableIndex = function (attrs) {
+  lunr.Index.call(this, attrs)
+  this.builder = attrs.builder
+}
+
+lunr.MutableIndex.prototype = new lunr.Index({})
+
+// XXX rebuilds the entire index =(
+// XXX refreshing this from newIndex is kinda wonky =(
+lunr.MutableIndex.prototype.add = function add (doc) {
+  this.builder.add(doc)
+
+  var newIndex = this.builder.build()
+  for (var k in newIndex) {
+    if (newIndex.hasOwnProperty(k)) {
+      this[k] = newIndex[k]
+    }
+  }
+}
+
+// XXX rebuilds the index twice
+lunr.MutableIndex.prototype.update = function update (doc) {
+  this.remove(doc)
+  this.add(doc)
+}
+
+// XXX rebuilds the entire index =(
+// XXX refreshing this from newIndex is kinda wonky =(
+lunr.MutableIndex.prototype.remove = function remove (doc) {
+  this.builder.remove(doc)
+
+  var newIndex = this.builder.build()
+  for (var k in newIndex) {
+    if (newIndex.hasOwnProperty(k)) {
+      this[k] = newIndex[k]
+    }
+  }
+}

--- a/lib/mutable_index.js
+++ b/lib/mutable_index.js
@@ -36,3 +36,24 @@ lunr.MutableIndex.prototype.remove = function remove (doc) {
     }
   }
 }
+
+lunr.MutableIndex.prototype.toJSON = function toJSON () {
+  var json = lunr.Index.prototype.toJSON.call(this)
+  json.builder = this.builder.toJSON()
+  return json
+}
+
+lunr.MutableIndex.load = function load (serializedIndex) {
+  var index = lunr.Index.load(serializedIndex)
+  var mutableIndex = new lunr.MutableIndex({})
+
+  for (var k in index) {
+    if (index.hasOwnProperty(k)) {
+      mutableIndex[k] = index[k]
+    }
+  }
+
+  mutableIndex.builder = lunr.MutableBuilder.load(serializedIndex.builder)
+
+  return mutableIndex
+}

--- a/lib/mutable_index.js
+++ b/lib/mutable_index.js
@@ -54,6 +54,9 @@ lunr.MutableIndex.load = function load (serializedIndex) {
   }
 
   mutableIndex.builder = lunr.MutableBuilder.load(serializedIndex.builder)
+  mutableIndex.builder.invertedIndex = mutableIndex.invertedIndex
+  mutableIndex.builder._fields = mutableIndex.fields
+  mutableIndex.builder.searchPipeline = mutableIndex.pipeline
 
   return mutableIndex
 }

--- a/lib/mutable_index.js
+++ b/lib/mutable_index.js
@@ -1,43 +1,43 @@
 lunr.MutableIndex = function (attrs) {
   lunr.Index.call(this, attrs)
   this.builder = attrs.builder
+  this._dirty = false
 }
 
 lunr.MutableIndex.prototype = new lunr.Index({})
 
-// XXX rebuilds the entire index =(
-// XXX refreshing this from newIndex is kinda wonky =(
 lunr.MutableIndex.prototype.add = function add (doc) {
   this.builder.add(doc)
-
-  var newIndex = this.builder.build()
-  for (var k in newIndex) {
-    if (newIndex.hasOwnProperty(k)) {
-      this[k] = newIndex[k]
-    }
-  }
+  this._dirty = true
 }
 
-// XXX rebuilds the index twice
 lunr.MutableIndex.prototype.update = function update (doc) {
   this.remove(doc)
   this.add(doc)
 }
 
-// XXX rebuilds the entire index =(
-// XXX refreshing this from newIndex is kinda wonky =(
 lunr.MutableIndex.prototype.remove = function remove (doc) {
   this.builder.remove(doc)
+  this._dirty = true
+}
 
-  var newIndex = this.builder.build()
-  for (var k in newIndex) {
-    if (newIndex.hasOwnProperty(k)) {
-      this[k] = newIndex[k]
+// XXX rebuilds the entire index =(
+// XXX refreshing this from newIndex is kinda wonky =(
+lunr.MutableIndex.prototype.checkDirty = function checkDirty () {
+  if (this._dirty) {
+    this._dirty = false
+    var newIndex = this.builder.build()
+    for (var k in newIndex) {
+      if (newIndex.hasOwnProperty(k)) {
+        this[k] = newIndex[k]
+      }
     }
   }
 }
 
 lunr.MutableIndex.prototype.toJSON = function toJSON () {
+  this.checkDirty()
+
   var json = lunr.Index.prototype.toJSON.call(this)
   json.builder = this.builder.toJSON()
   return json
@@ -57,6 +57,13 @@ lunr.MutableIndex.load = function load (serializedIndex) {
   mutableIndex.builder.invertedIndex = mutableIndex.invertedIndex
   mutableIndex.builder._fields = mutableIndex.fields
   mutableIndex.builder.searchPipeline = mutableIndex.pipeline
+  mutableIndex.dirty = false
 
   return mutableIndex
+}
+
+lunr.MutableIndex.prototype.query = function query (fn) {
+  this.checkDirty()
+
+  return lunr.Index.prototype.query.call(this, fn)
 }

--- a/test/mutable_serialization_test.js
+++ b/test/mutable_serialization_test.js
@@ -1,0 +1,95 @@
+suite('mutable serialization', function () {
+  setup(function () {
+    var documents = [{
+      id: 'a',
+      title: 'Mr. Green kills Colonel Mustard',
+      body: 'Mr. Green killed Colonel Mustard in the study with the candlestick. Mr. Green is not a very nice fellow.',
+      wordCount: 19
+    },{
+      id: 'b',
+      title: 'Plumb waters plant',
+      body: 'Professor Plumb has a green plant in his study',
+      wordCount: 9
+    },{
+      id: 'c',
+      title: 'Scarlett helps Professor',
+      body: 'Miss Scarlett watered Professor Plumbs green plant while he was away from his office last week.',
+      wordCount: 16
+    }]
+
+    var builder = new lunr.MutableBuilder
+
+    builder.pipeline.add(
+      lunr.trimmer,
+      lunr.stopWordFilter,
+      lunr.stemmer
+    )
+
+    builder.searchPipeline.add(
+      lunr.stemmer
+    )
+
+    var config = function () {
+      this.ref('id')
+      this.field('title')
+      this.field('body')
+
+      documents.forEach(function (document) {
+        this.add(document)
+      }, this)
+    }
+
+    config.call(builder, builder)
+
+    this.idx = builder.build()
+
+    this.idx.add({
+      id: 'd',
+      title: 'Naom Chomsky',
+      body: 'Colorless green ideas sleep furiously',
+      wordCount: 5
+    });
+
+    this.serializedIdx = JSON.stringify(this.idx)
+    this.loadedIdx = lunr.MutableIndex.load(JSON.parse(this.serializedIdx))
+  })
+
+  test('loadedAddWorked', function () {
+    this.loadedIdx.add({
+      id: 'e',
+      title: 'Naom Chomsky',
+      body: 'Colorless green ideas sleep furiously I think',
+      wordCount: 7
+    });
+    var results = this.loadedIdx.search('green')
+    assert.equal('a', results[0].ref)
+    assert.equal('b', results[1].ref)
+    assert.equal('d', results[2].ref)
+    assert.equal('e', results[3].ref)
+    assert.equal('c', results[4].ref)
+  })
+
+  test('loadedRemoveWorked', function () {
+    this.loadedIdx.remove({ id: 'b' });
+
+    var results = this.loadedIdx.search('green')
+    assert.equal('a', results[0].ref)
+    assert.equal('d', results[1].ref)
+    assert.equal('c', results[2].ref)
+  })
+
+  test('loadedUpdateWorked', function () {
+    this.loadedIdx.update({
+      id: 'd',
+      title: 'Naom Chomsky',
+      body: 'Et quo dolor velit iusto iure reprehenderit totam fugit Hic cumque distinctio consectetur suscipit qui itaque provident et Perspiciatis aut dolorum quia inventore hic Blanditiis error architecto vel et reprehenderit corporis sint Et sit modi non qui porro. Aut neque accusamus cumque nihil voluptates green',
+      wordCount: 46
+    });
+
+    var results = this.loadedIdx.search('green')
+    assert.equal('a', results[0].ref)
+    assert.equal('b', results[1].ref)
+    assert.equal('c', results[2].ref)
+    assert.equal('d', results[3].ref)
+  })
+})

--- a/test/mutable_test.js
+++ b/test/mutable_test.js
@@ -1,0 +1,85 @@
+suite('mutable indexes', function () {
+  setup(function () {
+    var documents = [{
+      id: 'a',
+      title: 'Mr. Green kills Colonel Mustard',
+      body: 'Mr. Green killed Colonel Mustard in the study with the candlestick. Mr. Green is not a very nice fellow.',
+      wordCount: 19
+    },{
+      id: 'b',
+      title: 'Plumb waters plant',
+      body: 'Professor Plumb has a green plant in his study',
+      wordCount: 9
+    },{
+      id: 'c',
+      title: 'Scarlett helps Professor',
+      body: 'Miss Scarlett watered Professor Plumbs green plant while he was away from his office last week.',
+      wordCount: 16
+    }]
+
+    var builder = new lunr.MutableBuilder
+
+    builder.pipeline.add(
+      lunr.trimmer,
+      lunr.stopWordFilter,
+      lunr.stemmer
+    )
+
+    builder.searchPipeline.add(
+      lunr.stemmer
+    )
+
+    var config = function () {
+      this.ref('id')
+      this.field('title')
+      this.field('body')
+
+      documents.forEach(function (document) {
+        this.add(document)
+      }, this)
+    }
+
+    config.call(builder, builder)
+
+    this.idx = builder.build()
+
+    this.idx.add({
+      id: 'd',
+      title: 'Naom Chomsky',
+      body: 'Colorless green ideas sleep furiously',
+      wordCount: 5
+    });
+  })
+
+  test('addWorked', function () {
+    var results = this.idx.search('green')
+    assert.equal('a', results[0].ref)
+    assert.equal('b', results[1].ref)
+    assert.equal('d', results[2].ref)
+    assert.equal('c', results[3].ref)
+  })
+
+  test('removeWorked', function () {
+    this.idx.remove({ id: 'b' });
+
+    var results = this.idx.search('green')
+    assert.equal('a', results[0].ref)
+    assert.equal('d', results[1].ref)
+    assert.equal('c', results[2].ref)
+  })
+
+  test('updateWorked', function () {
+    this.idx.update({
+      id: 'd',
+      title: 'Naom Chomsky',
+      body: 'Et quo dolor velit iusto iure reprehenderit totam fugit Hic cumque distinctio consectetur suscipit qui itaque provident et Perspiciatis aut dolorum quia inventore hic Blanditiis error architecto vel et reprehenderit corporis sint Et sit modi non qui porro. Aut neque accusamus cumque nihil voluptates green',
+      wordCount: 46
+    });
+
+    var results = this.idx.search('green')
+    assert.equal('a', results[0].ref)
+    assert.equal('b', results[1].ref)
+    assert.equal('c', results[2].ref)
+    assert.equal('d', results[3].ref)
+  })
+})


### PR DESCRIPTION
Hi there! I chimed in a separate issue about mutable indexes for 2.x, and I took a stab at adding them for my own purposes.  This PR (which I don't expect you to merge if you don't want to - I just wanted to share my work, get some review, and start a conversation) is the result of that work.  I'll be trying this for my FTS TiddlyWiki plugin - if it's something you're not interested in merging in, I can always publish it as a separate module, perhaps.

I made a few tradeoffs for this initial implementation:

  * Mutable indexes work by having a handle to their original builder - obviously this inflates the index size a bit.  For my purposes, I've considered this to be an acceptable tradeoff.
  * There's no sugar like `lunr(function() { ... })` for mutable indexes - I might add that later.
  * Changing a builder's tokenizer won't persist across serialization boundaries - I may add this if a) I can figure out the best way how and b) there's interest.
  * Gaps in `builder.termIndex` may build up when documents are deleted - I consider this to be acceptable since in the kinds of documents I'm working with, terms will seldom disappear permanently.
  * The index is completely rebuilt when a document is added/updated/removed - I intend on changing index operations to lazily refresh the index contents to cut down on redundant calculations.

JavaScript isn't a language that I "speak" fluently, so any feedback on idioms that I may have improperly used and how to correct them would be most welcome.  I would appreciate any feedback on this, even "this won't work because of X, Y, and Z" because that would save me some headaches. =)