### PR TITLE
Fix matchData.metadata keys for multiple-term matches.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -238,7 +238,7 @@ lunr.Index.prototype.query = function (fn) {
             if ((fieldMatch = matchingFields[matchingFieldRef]) === undefined) {
               matchingFields[matchingFieldRef] = new lunr.MatchData (expandedTerm, field, metadata)
             } else {
-              fieldMatch.add(expandedTerm, term, metadata)
+              fieldMatch.add(expandedTerm, field, metadata)
             }
 
           }

--- a/test/search_test.js
+++ b/test/search_test.js
@@ -123,6 +123,8 @@ suite('search', function () {
 
       test('matched terms returned', function () {
         assert.sameMembers(['fellow', 'candlestick'], Object.keys(this.results[0].matchData.metadata))
+        assert.sameMembers(['body'], Object.keys(this.results[0].matchData.metadata['fellow']));
+        assert.sameMembers(['body'], Object.keys(this.results[0].matchData.metadata['candlestick']));
       })
     })
 


### PR DESCRIPTION
Fixes #320.