### PR TITLE
Clone clause in Index.query loop

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -163,6 +163,7 @@ lunr.Index.prototype.query = function (fn) {
        * simplest way to do this is to re-use the clause object but mutate
        * its term property.
        */
+      clause = JSON.parse(JSON.stringify(clause))
       clause.term = term
 
       /*


### PR DESCRIPTION
In a tool that uses lunr.js client-side, and performs searches with a fuzzy query (literal, trailing wildcard, editDistance of 1), lunr.js was crashing (erratically) on iOS browsers with:
```
ReferenceError: posting is not defined
```
Digging further, we found that the strings in ``expandedTerms`` were somehow being corrupted. Skipping the corrupted items got the system working, but (of course) search results differed on iOS and Linux (we didn't test Windows). Cloning the ``clause`` object as in this pull request gets us identical results on the two platforms.

Not sure what's going on there. Maybe the JS engine in iOS does some sort of optimization on objects in a loop.