### PR TITLE
Pipeline performance improvement for large fields

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -209,7 +209,12 @@ lunr.Pipeline.prototype.run = function (tokens) {
 
       if (result === void 0 || result === '') return memo
 
-      return memo.concat(result)
+      if (result instanceof Array) 
+        Array.prototype.push.apply(memo, result)
+      else 
+        memo.push(result)
+
+      return memo
     }, [])
   }
 

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -203,19 +203,23 @@ lunr.Pipeline.prototype.run = function (tokens) {
 
   for (var i = 0; i < stackLength; i++) {
     var fn = this._stack[i]
+    var memo = []
 
-    tokens = tokens.reduce(function (memo, token, j) {
-      var result = fn(token, j, tokens)
+    for (var j = 0; j < tokens.length; j++) {
+      var result = fn(tokens[j], j, tokens)
 
-      if (result === void 0 || result === '') return memo
+      if (result === void 0 || result === '') continue
 
-      if (result instanceof Array) 
-        Array.prototype.push.apply(memo, result)
-      else 
+      if (result instanceof Array) {
+        for (var k = 0; k < result.length; k++) {
+          memo.push(result[k])
+        }
+      } else {
         memo.push(result)
+      }
+    }
 
-      return memo
-    }, [])
+    tokens = memo
   }
 
   return tokens

--- a/perf/pipeline_perf.js
+++ b/perf/pipeline_perf.js
@@ -1,0 +1,43 @@
+suite('lunr.Pipeline', function () {  
+  var tokenToToken = function(token) {
+    return token
+  }
+
+  var tokenToTokenArray = function(token) {
+    return [token, token]
+  }
+
+  var buildTokens = function(count) {
+    return words.slice(0, count).map(function(word) { 
+      return new lunr.Token(word) 
+    })
+  }
+
+  lunr.Pipeline.registerFunction(tokenToToken, 'tokenToToken')
+  lunr.Pipeline.registerFunction(tokenToTokenArray, 'tokenToTokenArray')
+
+  var fewTokens = buildTokens(50);
+  var manyTokens = buildTokens(1000)
+  
+  var tokenToTokenPipeline = new lunr.Pipeline
+  tokenToTokenPipeline.add(tokenToToken)
+
+  var tokenToTokenArrayPipeline = new lunr.Pipeline
+  tokenToTokenArrayPipeline.add(tokenToTokenArray)
+
+  this.add('few tokens, token -> token', function () {
+    tokenToTokenPipeline.run(fewTokens)
+  })
+
+  this.add('many tokens, token -> token', function () {
+    tokenToTokenPipeline.run(manyTokens)
+  })
+
+  this.add('few tokens, token -> token array', function () {
+    tokenToTokenArrayPipeline.run(fewTokens)
+  })
+
+  this.add('many tokens, token -> token array', function () {
+    tokenToTokenArrayPipeline.run(manyTokens)
+  })
+})


### PR DESCRIPTION
First, thanks for this library, I'm finding it extremely useful.

I was seeing poor performance adding very large fields to an index, which I tracked down to an array concat operation in the pipeline.   Here are some sample numbers from my environment:

Standard Lunr:
- Add field with 4000 tokens: **250** ms
- Add field with 30000 tokens: **8000** ms

With this fix:
- Add field with 4000 tokens: **20** ms
- Add field with 30000 tokens: **200** ms

Regards

Andy