### PR TITLE
Add multi-term support to Query#term

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
           "attrs", "tf", "idf", "lookups", "whitelist", "whitelisted", "tokenizer",
           "whitespace", "automata", "i", "obj", "anymore", "lexer", "var", "refs",
           "serializable", "tis", "twas", "int", "args", "unshift", "plugins", "upsert",
-          "upserting"
+          "upserting", "tokenization"
         ]
       }
     ],

--- a/lib/query.js
+++ b/lib/query.js
@@ -98,8 +98,14 @@ lunr.Query.prototype.clause = function (clause) {
  * Adds a term to the current query, under the covers this will create a {@link lunr.Query~Clause}
  * to the list of clauses that make up this query.
  *
- * @param {string} term - The term to add to the query.
- * @param {Object} [options] - Any additional properties to add to the query clause.
+ * The term is used as is, i.e. no tokenization will be performed by this method. Instead conversion
+ * to a token or token-like string should be done before calling this method.
+ *
+ * The term will be converted to a string by calling `toString`. Multiple terms can be passed as an
+ * array, each term in the array will share the same options.
+ *
+ * @param {object|object[]} term - The term(s) to add to the query.
+ * @param {object} [options] - Any additional properties to add to the query clause.
  * @returns {lunr.Query}
  * @see lunr.Query#clause
  * @see lunr.Query~Clause
@@ -111,10 +117,17 @@ lunr.Query.prototype.clause = function (clause) {
  *   boost: 10,
  *   wildcard: lunr.Query.wildcard.TRAILING
  * })
+ * @example <caption>using lunr.tokenizer to convert a string to tokens before using them as terms</caption>
+ * query.term(lunr.tokenizer("foo bar"))
  */
 lunr.Query.prototype.term = function (term, options) {
+  if (Array.isArray(term)) {
+    term.forEach(function (t) { this.term(t, options) }, this)
+    return this
+  }
+
   var clause = options || {}
-  clause.term = term
+  clause.term = term.toString()
 
   this.clause(clause)
 

--- a/test/query_test.js
+++ b/test/query_test.js
@@ -1,6 +1,70 @@
 suite('lunr.Query', function () {
   var allFields = ['title', 'body']
 
+  suite('#term', function () {
+    setup(function () {
+      this.query = new lunr.Query (allFields)
+    })
+
+    suite('single string term', function () {
+      setup(function () {
+        this.query.term('foo')
+      })
+
+      test('adds a single clause', function () {
+        assert.equal(this.query.clauses.length, 1)
+      })
+
+      test('clause has the correct term', function () {
+        assert.equal(this.query.clauses[0].term, 'foo')
+      })
+    })
+
+    suite('single token term', function () {
+      setup(function () {
+        this.query.term(new lunr.Token('foo'))
+      })
+
+      test('adds a single clause', function () {
+        assert.equal(this.query.clauses.length, 1)
+      })
+
+      test('clause has the correct term', function () {
+        assert.equal(this.query.clauses[0].term, 'foo')
+      })
+    })
+
+    suite('multiple string terms', function () {
+      setup(function () {
+        this.query.term(['foo', 'bar'])
+      })
+
+      test('adds a single clause', function () {
+        assert.equal(this.query.clauses.length, 2)
+      })
+
+      test('clause has the correct term', function () {
+        var terms = this.query.clauses.map(function (c) { return c.term })
+        assert.sameMembers(terms, ['foo', 'bar'])
+      })
+    })
+
+    suite('multiple token terms', function () {
+      setup(function () {
+        this.query.term(lunr.tokenizer('foo bar'))
+      })
+
+      test('adds a single clause', function () {
+        assert.equal(this.query.clauses.length, 2)
+      })
+
+      test('clause has the correct term', function () {
+        var terms = this.query.clauses.map(function (c) { return c.term })
+        assert.sameMembers(terms, ['foo', 'bar'])
+      })
+    })
+  })
+
   suite('#clause', function () {
     setup(function () {
       this.query = new lunr.Query (allFields)


### PR DESCRIPTION
Previously a single term could be passed to the Query#term method,
additionally this term needed to be a string. No tokenization is
performed by this method. The API was a bit cumbersome when dealing
with user entered queries, tokenization had to be done manually, and
then the results manually iterated over and used with Query#term.

This change improves matters in two ways:

* Lists of terms are supported
* A term can be anything that responds to `toString`

Together these two changes make it possible to directly use the
lunr.tokenizer when passing strings to Query#term.