### PR TITLE
Adds eslint settings to ignore mocha/chai

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,12 @@
 {
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "mocha": true
   },
-
   "globals": {
-    "lunr": true
+    "lunr": true,
+    "assert": true
   },
 
   "extends": "eslint:recommended",


### PR DESCRIPTION
Red squiggles for `test`, `suite`, and `assert` all go away in VS Code + ESLint plugin with these changes.