### PR TITLE
Normalize unicode to avoid index corruption; fixes issue #279

### DIFF
--- a/lunr.js
+++ b/lunr.js
@@ -2038,8 +2038,13 @@ lunr.Index.prototype.query = function (fn) {
          * For each term get the posting and termIndex, this is required for
          * building the query vector.
          */
-        var expandedTerm = expandedTerms[j],
-            posting = this.invertedIndex[expandedTerm],
+        var expandedTerm = expandedTerms[j]
+
+        if (typeof String.prototype.normalize === "function") {
+          expandedTerm = expandedTerm.normalize("NFC")
+        }
+
+        var posting = this.invertedIndex[expandedTerm],
             termIndex = posting._index
 
         for (var k = 0; k < clause.fields.length; k++) {


### PR DESCRIPTION
I know there's interest in rebuilding the tokenizer to resolve the issues with the trimmer that cause this bug, but for a short-term fix this does the trick. Would be great to make this available now to provide immediate relief so people don't have to switch to another library.