### PR TITLE
Use Array.isArray to check if pipeline output is an array

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -210,7 +210,7 @@ lunr.Pipeline.prototype.run = function (tokens) {
 
       if (result === void 0 || result === '') continue
 
-      if (result instanceof Array) {
+      if (Array.isArray(result)) {
         for (var k = 0; k < result.length; k++) {
           memo.push(result[k])
         }


### PR DESCRIPTION
TiddlyWiki (https://tiddlywiki.com), when run on Node, loads all of its
modules via Node's `vm.runInContext`.  This means that for my full text search
plugin (https://github.com/hoelzro/tw-full-text-search/), there is a
pipeline function loaded in its own context, separate from the context
lunr is loaded in.  This mismatch of contexts causes
`result instanceof Array` to always evaluate to false, which causes lunr
to break in further ways down the line.