### PR TITLE
Make sure fuzzy strings have fuzziness at the end

### DIFF
--- a/lib/token_set.js
+++ b/lib/token_set.js
@@ -117,13 +117,13 @@ lunr.TokenSet.fromFuzzyString = function (str, editDistance) {
 
       if (frame.str.length == 1) {
         noEditNode.final = true
-      } else {
-        stack.push({
-          node: noEditNode,
-          editsRemaining: frame.editsRemaining,
-          str: frame.str.slice(1)
-        })
       }
+
+      stack.push({
+        node: noEditNode,
+        editsRemaining: frame.editsRemaining,
+        str: frame.str.slice(1)
+      })
     }
 
     // deletion

--- a/test/token_set_test.js
+++ b/test/token_set_test.js
@@ -272,6 +272,7 @@ suite('lunr.TokenSet', function () {
           x4 = lunr.TokenSet.fromString('bar'),
           x5 = lunr.TokenSet.fromString('ba'),
           x6 = lunr.TokenSet.fromString('foo'),
+          x7 = lunr.TokenSet.fromString('bara'),
           y = lunr.TokenSet.fromFuzzyString('bar', 1)
 
       assert.sameMembers(x1.intersect(y).toArray(), ["bbar"])
@@ -280,6 +281,7 @@ suite('lunr.TokenSet', function () {
       assert.sameMembers(x4.intersect(y).toArray(), ["bar"])
       assert.sameMembers(x5.intersect(y).toArray(), ["ba"])
       assert.equal(x6.intersect(y).toArray().length, 0)
+      assert.sameMembers(x7.intersect(y).toArray(), ["bara"])
     })
 
     test('intersect with fuzzy string transpose', function () {


### PR DESCRIPTION
Fixes GH #375

Before, insertions were not made at the end of a fuzzy string for
token sets