### PR TITLE
Fix documentation around omitting a token via pipeline

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -44,7 +44,7 @@ lunr.Pipeline.registeredFunctions = Object.create(null)
  * or mutate (or add) metadata for a given token.
  *
  * A pipeline function can indicate that the passed token should be discarded by returning
- * null. This token will not be passed to any downstream pipeline functions and will not be
+ * undefined. This token will not be passed to any downstream pipeline functions and will not be
  * added to the index.
  *
  * Multiple tokens can be returned by returning an array of tokens. Each token will be passed


### PR DESCRIPTION
The code, tests, and module-level documentation say that you should return
undefined