### PR TITLE
Mention additional privacy motivation for client-side search

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Lunr.js is a small, full-text search library for use in the browser.  It indexes
 
 ## Why
 
-For web applications with all their data already sitting in the client, it makes sense to be able to search that data on the client too.  It saves adding extra, compacted services on the server.  A local search index will be quicker, there is no network overhead, and will remain available and usable even without a network connection.
+For web applications with all their data already sitting in the client, it makes sense to be able to search that data on the client too.  It saves adding extra, compacted services on the server.  A local search index will be quicker, there is no network overhead, and will remain available and usable even without a network connection.  It also provides some level of privacy protection for the user, as the terms searched for are not sent to the server.
 
 ## Installation
 


### PR DESCRIPTION
If the searched documents are the equivalent to a library, then client
side search is like hiding what you're reading in the library from the
server.  The server knows that you visited the library, but they don't
necessarily get to know what you were interested in.