### PR TITLE
docs: Fix a few typos

### DIFF
--- a/lunr.js
+++ b/lunr.js
@@ -3456,7 +3456,7 @@ lunr.QueryParser.parseBoost = function (parser) {
     } else if (typeof exports === 'object') {
       /**
        * Node. Does not work with strict CommonJS, but
-       * only CommonJS-like enviroments that support module.exports,
+       * only CommonJS-like environments that support module.exports,
        * like Node.
        */
       module.exports = factory()

--- a/test/env/mocha.js
+++ b/test/env/mocha.js
@@ -7055,7 +7055,7 @@ function alloc (that, size, fill, encoding) {
   if (fill !== undefined) {
     // Only pay attention to encoding if it's a string. This
     // prevents accidentally sending in a number that would
-    // be interpretted as a start offset.
+    // be interpreted as a start offset.
     return typeof encoding === 'string'
       ? createBuffer(that, size).fill(fill, encoding)
       : createBuffer(that, size).fill(fill)
@@ -7344,7 +7344,7 @@ function slowToString (encoding, start, end) {
     return ''
   }
 
-  // Force coersion to uint32. This will also coerce falsey/NaN values to 0.
+  // Force coercion to uint32. This will also coerce falsey/NaN values to 0.
   end >>>= 0
   start >>>= 0
 
@@ -9781,7 +9781,7 @@ exports.version = '1.4.1'
  *  - sticky  Make the notification stick (defaults to false)
  *  - priority  Specify an int or named key (default is 0)
  *  - name    Application name (defaults to growlnotify)
- *  - sound   Sound efect ( in OSx defined in preferences -> sound -> effects) * works only in OSX > 10.8x
+ *  - sound   Sound effect ( in OSx defined in preferences -> sound -> effects) * works only in OSX > 10.8x
  *  - image
  *    - path to an icon sets --iconpath
  *    - path to an image sets --image
@@ -12375,7 +12375,7 @@ process.nextTick = function (fun) {
     }
 };
 
-// v8 likes predictible objects
+// v8 likes predictable objects
 function Item(fun, array) {
     this.fun = fun;
     this.array = array;

--- a/test/token_set_test.js
+++ b/test/token_set_test.js
@@ -59,7 +59,7 @@ suite('lunr.TokenSet', function () {
       // a state reached by a wildcard has
       // an edge with a wildcard to itself.
       // the resulting automota is
-      // non-determenistic
+      // non-deterministic
       assert.equal(wild, wild.edges['*'])
       assert.isOk(wild.final)
     })


### PR DESCRIPTION
There are small typos in:
- lunr.js
- test/env/mocha.js
- test/token_set_test.js

Fixes:
- Should read `predictable` rather than `predictible`.
- Should read `interpreted` rather than `interpretted`.
- Should read `environments` rather than `enviroments`.
- Should read `effect` rather than `efect`.
- Should read `deterministic` rather than `determenistic`.
- Should read `coercion` rather than `coersion`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md