### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/stemmer.js
+++ b/lib/stemmer.js
@@ -98,9 +98,9 @@ lunr.stemmer = (function(){
 
     if (w.length < 3) { return w; }
 
-    firstch = w.substr(0,1);
+    firstch = w.slice(0,1);
     if (firstch == "y") {
-      w = firstch.toUpperCase() + w.substr(1);
+      w = firstch.toUpperCase() + w.slice(1);
     }
 
     // Step 1a
@@ -209,7 +209,7 @@ lunr.stemmer = (function(){
     // and turn initial Y back to y
 
     if (firstch == "y") {
-      w = firstch.toLowerCase() + w.substr(1);
+      w = firstch.toLowerCase() + w.slice(1);
     }
 
     return w;

--- a/lunr.js
+++ b/lunr.js
@@ -1026,9 +1026,9 @@ lunr.stemmer = (function(){
 
     if (w.length < 3) { return w; }
 
-    firstch = w.substr(0,1);
+    firstch = w.slice(0,1);
     if (firstch == "y") {
-      w = firstch.toUpperCase() + w.substr(1);
+      w = firstch.toUpperCase() + w.slice(1);
     }
 
     // Step 1a
@@ -1137,7 +1137,7 @@ lunr.stemmer = (function(){
     // and turn initial Y back to y
 
     if (firstch == "y") {
-      w = firstch.toLowerCase() + w.substr(1);
+      w = firstch.toLowerCase() + w.slice(1);
     }
 
     return w;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.