### PR TITLE
Switch to strict mode and fix `this` usage issue

### DIFF
--- a/build/wrapper_end
+++ b/build/wrapper_end
@@ -1,13 +1,13 @@
 
   /**
    * export the module via AMD, CommonJS or as a browser global
-   * Export code from https://github.com/umdjs/umd/blob/master/returnExports.js
+   * Export code from https://github.com/umdjs/umd/blob/master/templates/returnExports.js
    */
   ;(function (root, factory) {
     if (typeof define === 'function' && define.amd) {
       // AMD. Register as an anonymous module.
-      define(factory)
-    } else if (typeof exports === 'object') {
+      define([], factory)
+    } else if (typeof module === 'object' && module.exports) {
       /**
        * Node. Does not work with strict CommonJS, but
        * only CommonJS-like enviroments that support module.exports,
@@ -18,7 +18,7 @@
       // Browser globals (root is window)
       root.lunr = factory()
     }
-  }(this, function () {
+  }(typeof self !== 'undefined' ? self : this, function () {
     /**
      * Just return a value to define the module export.
      * This example returns an object, but the module

--- a/build/wrapper_start
+++ b/build/wrapper_start
@@ -5,4 +5,4 @@
  */
 
 ;(function(){
-
+  'use strict';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,15 +16,14 @@ lunr.utils = {}
  * @memberOf lunr.utils
  * @function
  */
-lunr.utils.warn = (function (global) {
+lunr.utils.warn = function (message) {
   /* eslint-disable no-console */
-  return function (message) {
-    if (global.console && console.warn) {
-      console.warn(message)
-    }
+  if (typeof console !== 'undefined' && console.warn) {
+    console.warn(message)
   }
   /* eslint-enable no-console */
-})(this)
+}
+
 
 /**
  * Convert an object to a string.

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+    "env": {
+        "mocha": true
+    },
+    "globals": {
+        "assert": false
+    }
+}

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -74,4 +74,42 @@ suite('lunr.utils', function () {
       })
     })
   })
+
+  suite('#warn', function () {
+    test('do nothing when console or console.warn is not implemented', function () {
+      var root = typeof self !== 'undefined' ? self : global
+      var origConsole = root.console
+
+      try {
+        root.console = undefined
+        lunr.utils.warn('foo')
+
+        root.console = {}
+        lunr.utils.warn('foo')
+      } finally {
+        root.console = origConsole
+      }
+    })
+
+    test('calls console.warn', function () {
+      var root = typeof self !== 'undefined' ? self : global
+      var origConsole = root.console
+
+      try {
+        var warnCalled = false
+
+        root.console = Object.create(root.console)
+        root.console.warn = function (message) {
+          assert.equal(message, 'foo')
+          warnCalled = true
+        }
+
+        lunr.utils.warn('foo')
+
+        assert.equal(warnCalled, true)
+      } finally {
+        root.console = origConsole
+      }
+    })
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/olivernn/lunr.js/issues/324 (allowing lunr.js import as module and usage in other strict environments) by switching lunr itself to strict mode and fixing `this` usage.

`wrapper_end` was updated to the latest version of template, which uses `self` to access window and thus works in strict mode.

`lurn.utils.warn` was changed as in https://github.com/olivernn/lunr.js/pull/411.

Added tests check conditional usage of console. Tests succeed in both Node and browser.