### PR TITLE
Remove (dead) `lunr.min.js` link from `index.html`

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,10 +84,7 @@
           <h3>Download</h3>
         </header>
 
-        <ul>
-          <li><a href="https://raw.github.com/olivernn/lunr.js/master/lunr.js">lunr.js</a> - uncompressed</li>
-          <li><a href="https://raw.github.com/olivernn/lunr.js/master/lunr.min.js">lunr.min.js</a> - minified</li>
-        </ul>
+        <a href="https://raw.github.com/olivernn/lunr.js/master/lunr.js">lunr.js</a>
       </article>
     </section>
 


### PR DESCRIPTION
The `lunr.min.js` file was removed in https://github.com/olivernn/lunr.js/commit/2a57c5334f2df69c8d41bceae1e5b6c66502342d, but is still referenced.